### PR TITLE
Setup dev env: Android CLI tools docs and Valdi CLI improvements

### DIFF
--- a/docs/setup/linux_setup.md
+++ b/docs/setup/linux_setup.md
@@ -42,7 +42,7 @@ git lfs install
 
 Download and install Android Studio by following [Google's directions](https://developer.android.com/studio).
 
-Open any project, navigate to `Tools` -> `SDK Manager`
+Open the Android SDK Manager. You can find it on the main screen of Android Studio under `More Actions` -> `SDK Manager`. When a project is open, you can also find it under `Tools` -> `SDK Manager`.
 
 Under **SDK Platforms**, install **API level 35**.
 
@@ -51,6 +51,8 @@ Under **SDK Tools**, uncheck `Hide obsolete packages` check `Show Package Detail
 Install build tools **version 34.0.0**.
 
 Install ndk version **25.2.9519653**
+
+Install the latest version of **Android SDK Command-line Tools**
 
 Add the following to your `.bashrc`
 

--- a/docs/setup/macos_setup.md
+++ b/docs/setup/macos_setup.md
@@ -67,7 +67,7 @@ git lfs install
 
 Download and install Android Studio by following [Google's directions](https://developer.android.com/studio).
 
-Open any project, navigate to `Tools` -> `SDK Manager`
+Open the Android SDK Manager. You can find it on the main screen of Android Studio under `More Actions` -> `SDK Manager`. When a project is open, you can also find it under `Tools` -> `SDK Manager`.
 
 Under **SDK Platforms**, install **API level 35**.
 
@@ -76,6 +76,8 @@ Under **SDK Tools**, uncheck `Hide obsolete packages` check `Show Package Detail
 Install build tools **version 34.0.0**.
 
 Install ndk version **25.2.9519653**
+
+Install the latest version of **Android SDK Command-line Tools**
 
 Update `.zshrc` with the following:
 

--- a/npm_modules/cli/src/setup/linuxSetup.ts
+++ b/npm_modules/cli/src/setup/linuxSetup.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import { checkCommandExists } from '../utils/cliUtils';
 import { DevSetupHelper, HOME_DIR } from './DevSetupHelper';
-import { ANDROID_LINUX_COMMANDLINE_TOOLS } from './versions';
 
 const BAZELISK_URL = 'https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64';
 
@@ -32,7 +31,7 @@ export async function linuxSetup(): Promise<void> {
 
   await devSetup.writeEnvVariablesToRcFile([{ name: 'PATH', value: `"$HOME/.valdi/bin:$PATH"` }]);
 
-  await devSetup.setupAndroidSDK(ANDROID_LINUX_COMMANDLINE_TOOLS);
+  await devSetup.setupAndroidSDK();
 
   devSetup.onComplete();
 }

--- a/npm_modules/cli/src/setup/macOSSetup.ts
+++ b/npm_modules/cli/src/setup/macOSSetup.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import { CliError } from '../core/errors';
 import { checkCommandExists, runCliCommand } from '../utils/cliUtils';
 import { DevSetupHelper } from './DevSetupHelper';
-import { ANDROID_MACOS_COMMANDLINE_TOOLS } from './versions';
 
 export async function macOSSetup(): Promise<void> {
   const devSetup = new DevSetupHelper();
@@ -36,7 +35,7 @@ export async function macOSSetup(): Promise<void> {
 
   const javaHome = await runCliCommand('/usr/libexec/java_home');
 
-  await devSetup.setupAndroidSDK(ANDROID_MACOS_COMMANDLINE_TOOLS, javaHome.stdout.trim());
+  await devSetup.setupAndroidSDK(javaHome.stdout.trim());
 
   devSetup.onComplete();
 }

--- a/npm_modules/cli/src/setup/versions.ts
+++ b/npm_modules/cli/src/setup/versions.ts
@@ -1,8 +1,3 @@
 export const ANDROID_BUILD_TOOLS_VERSION = '34.0.0';
 export const ANDROID_NDK_VERSION = '25.2.9519653';
 export const ANDROID_PLATFORM_VERSION = 'android-35';
-
-export const ANDROID_MACOS_COMMANDLINE_TOOLS =
-  'https://dl.google.com/android/repository/commandlinetools-mac-13114758_latest.zip';
-export const ANDROID_LINUX_COMMANDLINE_TOOLS =
-  'https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip';


### PR DESCRIPTION
Since devs will need to setup some parts of the Android SDK themselves beforehand, as instructed in the MacOS and Linux setup guide, this PR adds a notice to install the latest Android SDK CLI Tools from the SDK Manager as well.

This PR also removes the manual download, unzip, copy and handling of the `sdkmanager`, but rather assumes the user has followed the setup guide and installed the tools from SDK Manager.

Fixes #1