### PR TITLE
fix: add github mirror url for boringssl to handle rate limiting

### DIFF
--- a/bzl/dependencies.bzl
+++ b/bzl/dependencies.bzl
@@ -173,9 +173,12 @@ def setup_dependencies(workspace_root = None):
         integrity = "sha256-rX/boR6gEcHZJbMonPSvLGajUuGNTHJkOS/q116Rk2M=",
     )
 
-    http_archive(
+     http_archive(
         name = "boringssl",
-        url = "https://boringssl.googlesource.com/boringssl/+archive/82f9853fc7d7360ae44f1e1357a6422c5244bbd8.tar.gz",
+        urls = [
+            "https://boringssl.googlesource.com/boringssl/+archive/82f9853fc7d7360ae44f1e1357a6422c5244bbd8.tar.gz",
+            "https://github.com/google/boringssl/archive/82f9853fc7d7360ae44f1e1357a6422c5244bbd8.tar.gz",
+        ],
     )
 
     # Used for networking, and other utilities like small_vector


### PR DESCRIPTION
issue : https://github.com/Snapchat/Valdi/issues/27


## Problem
Boringssl downloads fail with 429 Too Many Requests from Google's server

## Solution
Add GitHub as fallback URL in http_archive

## Changes
- Updated bzl/dependencies.bzl to use urls array with GitHub mirror