### PR TITLE
Add Fedora setup option depending of which distro you are in

### DIFF
--- a/npm_modules/cli/src/commands/doctor.ts
+++ b/npm_modules/cli/src/commands/doctor.ts
@@ -45,6 +45,7 @@ import { BazelClient } from '../utils/BazelClient';
 import { checkCommandExists, runCliCommand } from '../utils/cliUtils';
 import { makeCommandHandler } from '../utils/errorUtils';
 import { wrapInColor } from '../utils/logUtils';
+import { isFedora, isUbuntu } from '../setup/linuxSetup';
 
 /** Discord support link for troubleshooting */
 const DISCORD_SUPPORT_URL = 'https://discord.gg/uJyNEeYX2U';
@@ -1166,16 +1167,25 @@ class ValdiDoctor {
   private getFixCommandForDependency(dep: string): string {
     switch (dep) {
       case 'git': {
-        return os.platform() === 'darwin' ? 'brew install git' : 'sudo apt-get install git';
+        if (os.platform() === 'darwin') return 'brew install git';
+        if (isUbuntu) return 'sudo apt-get install git';
+        if (isFedora) return 'sudo dnf install git';
+        return 'Install git for your distribution';
       }
       case 'npm': {
         return 'Install Node.js from https://nodejs.org (includes npm)';
       }
       case 'watchman': {
-        return os.platform() === 'darwin' ? 'brew install watchman' : 'sudo apt-get install watchman';
+        if (os.platform() === 'darwin') return 'brew install watchman';
+        if (isUbuntu) return 'sudo apt-get install watchman';
+        if (isFedora) return 'sudo dnf install watchman';
+        return 'Install watchman for your distribution';
       }
       case 'git-lfs': {
-        return os.platform() === 'darwin' ? 'brew install git-lfs' : 'sudo apt-get install git-lfs';
+        if (os.platform() === 'darwin') return 'brew install git-lfs';
+        if (isUbuntu) return 'sudo apt-get install git-lfs';
+        if (isFedora) return 'sudo dnf install git-lfs';
+        return 'Install git-lfs for your distribution';
       }
       case 'bazelisk': {
         return os.platform() === 'darwin' ? 'brew install bazelisk' : 'valdi dev_setup';
@@ -1184,7 +1194,9 @@ class ValdiDoctor {
         return 'brew install ios-webkit-debug-proxy';
       }
       case 'adb': {
-        return 'sudo apt-get install adb';
+        if (isUbuntu) return 'sudo apt-get install adb';
+        if (isFedora) return 'sudo dnf install android-tools';
+        return 'Install adb for your distribution';
       }
       default: {
         return os.platform() === 'darwin' ? `brew install ${dep}` : `Install ${dep}`;

--- a/npm_modules/cli/src/setup/distros/fedoraSetup.ts
+++ b/npm_modules/cli/src/setup/distros/fedoraSetup.ts
@@ -1,0 +1,16 @@
+import { checkCommandExists } from "../../utils/cliUtils";
+import { DevSetupHelper } from "../DevSetupHelper";
+
+export async function fedoraSetup(devSetup: DevSetupHelper): Promise<void> {
+  await devSetup.runShell('Installing dependencies from dnf', [
+    `sudo dnf install zlib-devel git-lfs watchman fontconfig-devel android-tools`,
+  ]);
+
+  await devSetup.runShell('Installing ncurses-compat-libs', [
+    `sudo dnf install ncurses-compat-libs`,
+  ]);
+
+  if (!checkCommandExists('java')) {
+    await devSetup.runShell('Installing Java Runtime Environment', ['sudo dnf install default-jre']);
+  }
+}

--- a/npm_modules/cli/src/setup/distros/ubuntuSetup.ts
+++ b/npm_modules/cli/src/setup/distros/ubuntuSetup.ts
@@ -1,0 +1,17 @@
+import { checkCommandExists } from "../../utils/cliUtils";
+import { DevSetupHelper } from "../DevSetupHelper";
+
+export async function ubuntuSetup(devSetup: DevSetupHelper): Promise<void> {
+  await devSetup.runShell('Installing dependencies from apt', [
+    `sudo apt-get install zlib1g-dev git-lfs watchman libfontconfig-dev adb`,
+  ]);
+
+  await devSetup.runShell('Installing libtinfo5', [
+    `wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb`,
+    `sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb`,
+  ]);
+
+  if (!checkCommandExists('java')) {
+    await devSetup.runShell('Installing Java Runtime Environment', ['sudo apt install default-jre']);
+  }
+}

--- a/npm_modules/cli/src/setup/linuxSetup.ts
+++ b/npm_modules/cli/src/setup/linuxSetup.ts
@@ -1,26 +1,23 @@
 import fs from 'fs';
 import path from 'path';
-import { checkCommandExists } from '../utils/cliUtils';
 import { DevSetupHelper, HOME_DIR } from './DevSetupHelper';
 import { ANDROID_LINUX_COMMANDLINE_TOOLS } from './versions';
+import { wrapInColor } from '../utils/logUtils';
+import { ANSI_COLORS } from '../core/constants';
+import { ubuntuSetup } from './distros/ubuntuSetup';
+import { fedoraSetup } from './distros/fedoraSetup';
 
 const BAZELISK_URL = 'https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64';
+
+export const isFedora = fs.existsSync('/etc/fedora-release') || fs.existsSync('/etc/redhat-release');
+export const isUbuntu = fs.existsSync('/etc/lsb-release') || fs.existsSync('/etc/debian_version');
 
 export async function linuxSetup(): Promise<void> {
   const devSetup = new DevSetupHelper();
 
-  await devSetup.runShell('Installing dependencies from apt', [
-    `sudo apt-get install zlib1g-dev git-lfs watchman libfontconfig-dev adb`,
-  ]);
-
-  await devSetup.runShell('Installing libtinfo5', [
-    `wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb`,
-    `sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb`,
-  ]);
-
-  if (!checkCommandExists('java')) {
-    await devSetup.runShell('Installing Java Runtime Environment', ['sudo apt install default-jre']);
-  }
+  if (isUbuntu) ubuntuSetup(devSetup)
+  else if (isFedora) fedoraSetup(devSetup)
+  else console.log(wrapInColor('Your distro is not supported yet...aborting...', ANSI_COLORS.RED_COLOR));
 
   const bazeliskPathSuffix = '.valdi/bin/bazelisk';
   const bazeliskTargetPath = path.join(HOME_DIR, bazeliskPathSuffix);


### PR DESCRIPTION
Trying to install Valdi on my machine I got some problems trying to build, looking at the code I realized it was because I am using Fedora and the config was built to work with debian based distros.
This pull request add Linux distribution support in the CLI setup process, providing tailored installation commands and setup logic for both Ubuntu and Fedora systems. The changes improve the user experience by detecting the user's Linux distribution and running the appropriate dependency installation steps, rather than assuming all users are on Ubuntu. Additionally, the doctor command now gives more accurate instructions for resolving missing dependencies based on the detected distribution.

**Linux distribution detection and setup:**

* Added detection for Ubuntu and Fedora distributions in `linuxSetup.ts`, and refactored the main setup logic to delegate to new, distro-specific setup functions (`ubuntuSetup` and `fedoraSetup`). If an unsupported distro is detected, a clear error message is shown.
* Implemented `ubuntuSetup.ts` and `fedoraSetup.ts` to encapsulate the installation steps for each distribution, including dependency installation and Java runtime checks.

**Improved dependency installation instructions:**

* Updated the `ValdiDoctor` class to provide more accurate fix commands for missing dependencies, using `sudo apt-get` for Ubuntu, `sudo dnf` for Fedora, and a generic message for other distributions. 
* Imported the new distro detection helpers (`isFedora`, `isUbuntu`) into the doctor command for use in generating these instructions.

If anyone have any other changes feel free to change.