### PR TITLE
fix: disable bazel sandboxing for Linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,9 +22,8 @@ common --define enable_web=true
 build --tool_java_language_version=11
 build --java_language_version=11
 
-## Disable sandboxing for macs, both laptops and in CI; the performance hit is much too high.
-build:macos --spawn_strategy=local
-build:linux --sandbox_writable_path=/var/tmp
+## Disable sandboxing for both dev machines and in CI; the performance hit is much too high.
+build --spawn_strategy=local
 
 # common cc configuration
 build --cxxopt=-std=c++20
@@ -71,10 +70,6 @@ build --per_file_copt=external/com_github_google_flatbuffers/.*\$@-Wno-everythin
 
 # Enable persistent worker for Valdi compilation
 build --strategy=ValdiCompile=worker
-
-## Disable sandboxing for macs, both laptops and in CI; the performance hit is much too high.
-build:macos --spawn_strategy=local
-build:linux --sandbox_writable_path=/var/tmp
 
 # Disable disk cache to save disk space
 # https://docs.google.com/document/d/1N8W_M83n9jhMi7pgUhXuEuxypb3dmlHBu_CG_eXipXI/edit?usp=sharing

--- a/npm_modules/cli/.metadata/.bazelrc.template
+++ b/npm_modules/cli/.metadata/.bazelrc.template
@@ -19,9 +19,8 @@ common --define enable_web=true
 build --tool_java_language_version=11
 build --java_language_version=11
 
-## Disable sandboxing for macs, both laptops and in CI; the performance hit is much too high.
-build:macos --spawn_strategy=local
-build:linux --sandbox_writable_path=/var/tmp
+## Disable sandboxing for both dev machines and in CI; the performance hit is much too high.
+build --spawn_strategy=local
 
 # common cc configuration
 build --cxxopt=-std=c++20
@@ -69,9 +68,6 @@ build --per_file_copt=external/com_github_google_flatbuffers/.*\$@-Wno-everythin
 # Enable persistent worker for Valdi compilation
 build --strategy=ValdiCompile=worker
 
-## Disable sandboxing for macs, both laptops and in CI; the performance hit is much too high.
-build:macos --spawn_strategy=local
-build:linux --sandbox_writable_path=/var/tmp
 
 # Disable disk cache to save disk space
 # https://docs.google.com/document/d/1N8W_M83n9jhMi7pgUhXuEuxypb3dmlHBu_CG_eXipXI/edit?usp=sharing


### PR DESCRIPTION
- Parity with macOS (not sure why this was different in the first place)
- Fixes `valdi bootstrap` on Arch Linux