### PR TITLE
Fix: Add Fedora/RHEL support to Linux dev setup

### DIFF
--- a/npm_modules/cli/src/setup/linuxSetup.ts
+++ b/npm_modules/cli/src/setup/linuxSetup.ts
@@ -6,22 +6,62 @@ import { ANDROID_LINUX_COMMANDLINE_TOOLS } from './versions';
 
 const BAZELISK_URL = 'https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64';
 
+// Detect which package manager is available
+function detectPackageManager(): 'apt' | 'dnf' | 'yum' {
+  if (checkCommandExists('apt-get')) {
+    return 'apt';
+  } else if (checkCommandExists('dnf')) {
+    return 'dnf';
+  } else if (checkCommandExists('yum')) {
+    return 'yum';
+  } else {
+    throw new Error('No supported package manager found. Please install apt-get, dnf, or yum.');
+  }
+}
+
+// Get the correct package names for each package manager
+function getPackageNames(pm: 'apt' | 'dnf' | 'yum'): string[] {
+  const packages = {
+    apt: ['zlib1g-dev', 'git-lfs', 'watchman', 'libfontconfig-dev', 'adb'],
+    dnf: ['zlib-devel', 'git-lfs', 'watchman', 'fontconfig-devel', 'android-tools'],
+    yum: ['zlib-devel', 'git-lfs', 'watchman', 'fontconfig-devel', 'android-tools'],
+  };
+  return packages[pm];
+}
+
 export async function linuxSetup(): Promise<void> {
   const devSetup = new DevSetupHelper();
+  const packageManager = detectPackageManager();
+  const packages = getPackageNames(packageManager);
 
-  await devSetup.runShell('Installing dependencies from apt', [
-    `sudo apt-get install zlib1g-dev git-lfs watchman libfontconfig-dev adb`,
+  
+  // Install dependencies using the detected package manager
+  await devSetup.runShell(`Installing dependencies using ${packageManager}`, [
+    `sudo ${packageManager} install -y ${packages.join(' ')}`,
   ]);
 
-  await devSetup.runShell('Installing libtinfo5', [
-    `wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb`,
-    `sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb`,
-  ]);
-
-  if (!checkCommandExists('java')) {
-    await devSetup.runShell('Installing Java Runtime Environment', ['sudo apt install default-jre']);
+  // libtinfo5 installation - only for apt-based systems
+  if (packageManager === 'apt') {
+    await devSetup.runShell('Installing libtinfo5', [
+      `wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb`,
+      `sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb`,
+    ]);
+  } else {
+    // For Fedora/RHEL, ncurses-compat-libs provides libtinfo5
+    await devSetup.runShell('Installing ncurses compatibility libraries', [
+      `sudo ${packageManager} install -y ncurses-compat-libs`,
+    ]);
   }
 
+  // Install Java if not present
+  if (!checkCommandExists('java')) {
+    const javaPackage = packageManager === 'apt' ? 'default-jre' : 'java-latest-openjdk';
+    await devSetup.runShell('Installing Java Runtime Environment', [
+      `sudo ${packageManager} install -y ${javaPackage}`,
+    ]);
+  }
+
+  // Install Bazelisk
   const bazeliskPathSuffix = '.valdi/bin/bazelisk';
   const bazeliskTargetPath = path.join(HOME_DIR, bazeliskPathSuffix);
   await devSetup.downloadToPath(BAZELISK_URL, bazeliskTargetPath);


### PR DESCRIPTION
- Auto-detect package manager (apt/dnf/yum)
- Map package names for different distros
- Handle libtinfo5 installation for both Ubuntu and Fedora
- Fix Java package names for different distros
- Fixes #38