### PR TITLE
# Security: Add URL validation to prevent SSRF in HTTPRequestManager

### DIFF
--- a/src/valdi_modules/src/cpp/valdi_http/HTTPRequestManagerModuleFactory.cpp
+++ b/src/valdi_modules/src/cpp/valdi_http/HTTPRequestManagerModuleFactory.cpp
@@ -53,7 +53,7 @@ Value HTTPRequestManagerModuleFactory::loadModule() {
             // Validate URL to prevent SSRF attacks
             if (!HTTPRequestManagerUtils::isUrlAllowed(url)) {
                 callContext.getExceptionTracker().onError(
-                    Error("URL not allowed: blocked localhost, private IP, or cloud metadata"));
+                    Error("URL not allowed!"));
                 return Value::undefined();
             }
             

--- a/src/valdi_modules/src/cpp/valdi_http/HTTPRequestManagerModuleFactory.cpp
+++ b/src/valdi_modules/src/cpp/valdi_http/HTTPRequestManagerModuleFactory.cpp
@@ -49,6 +49,14 @@ Value HTTPRequestManagerModuleFactory::loadModule() {
 
             const auto& requestObject = callContext.getParameter(0);
             auto url = requestObject.getMapValue("url").toStringBox();
+            
+            // Validate URL to prevent SSRF attacks
+            if (!HTTPRequestManagerUtils::isUrlAllowed(url)) {
+                callContext.getExceptionTracker().onError(
+                    Error("URL not allowed: blocked localhost, private IP, or cloud metadata"));
+                return Value::undefined();
+            }
+            
             auto method = requestObject.getMapValue("method").toStringBox();
             auto headers = requestObject.getMapValue("headers");
             auto body = requestObject.getMapValue("body").getTypedArrayRef();

--- a/valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.cpp
+++ b/valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.cpp
@@ -43,37 +43,32 @@ bool HTTPRequestManagerUtils::isUrlAllowed(const StringBox& url) {
     
     std::string_view urlView = url.toStringView();
     
-    // Convert to lowercase for case-insensitive comparison
     std::string urlLower;
     urlLower.reserve(urlView.size());
     std::transform(urlView.begin(), urlView.end(), std::back_inserter(urlLower),
                    [](unsigned char c) { return std::tolower(c); });
     std::string_view urlLowerView(urlLower);
     
-    // Only allow http:// and https:// schemes
     if (urlLowerView.find("http://") != 0 && urlLowerView.find("https://") != 0) {
         return false;
     }
     
-    // Extract host part (between :// and / or end of string)
     size_t schemeEnd = urlLowerView.find("://");
     if (schemeEnd == std::string_view::npos) {
         return false;
     }
-    schemeEnd += 3; // Skip "://"
+    schemeEnd += 3;
     
     size_t hostEnd = urlLowerView.find_first_of("/?#", schemeEnd);
     std::string_view hostPart = hostEnd == std::string_view::npos 
         ? urlLowerView.substr(schemeEnd)
         : urlLowerView.substr(schemeEnd, hostEnd - schemeEnd);
     
-    // Remove port if present
     size_t portStart = hostPart.find(':');
     if (portStart != std::string_view::npos) {
         hostPart = hostPart.substr(0, portStart);
     }
     
-    // Block localhost and loopback addresses
     if (hostPart == "localhost" ||
         hostPart == "127.0.0.1" ||
         hostPart == "::1" ||
@@ -82,22 +77,18 @@ bool HTTPRequestManagerUtils::isUrlAllowed(const StringBox& url) {
         return false;
     }
     
-    // Block cloud metadata service hostnames
     if (hostPart == "metadata.google.internal" ||
         hostPart == "169.254.169.254") {
         return false;
     }
     
-    // Block private IP ranges - check if host starts with private IP prefixes
     if (hostPart.length() >= 3 && hostPart.substr(0, 3) == "10.") {
         if (hostPart.length() > 3 && std::isdigit(hostPart[3])) {
             return false;
         }
     }
     
-    // 172.16.0.0/12 (172.16.0.0 to 172.31.255.255)
     if (hostPart.length() >= 7 && hostPart.substr(0, 4) == "172.") {
-        // Check if second octet is 16-31
         if (hostPart.length() > 4 && std::isdigit(hostPart[4])) {
             size_t secondDot = hostPart.find('.', 4);
             if (secondDot != std::string_view::npos && secondDot > 4) {

--- a/valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.cpp
+++ b/valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.cpp
@@ -10,7 +10,10 @@
 #include <string_view>
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <string>
+#include <sstream>
+#include <iomanip>
 
 namespace Valdi {
 
@@ -36,6 +39,321 @@ std::shared_ptr<snap::valdi_core::HTTPRequestManagerCompletion> HTTPRequestManag
     return Valdi::makeShared<HTTPRequestManagerCompletionWithFunction>(std::move(function));
 }
 
+namespace {
+    // Decode URL-encoded characters to prevent encoding bypasses
+    std::string urlDecode(const std::string_view& encoded) {
+        std::string decoded;
+        decoded.reserve(encoded.length());
+        
+        for (size_t i = 0; i < encoded.length(); ++i) {
+            if (encoded[i] == '%' && i + 2 < encoded.length()) {
+                char hex1 = encoded[i + 1];
+                char hex2 = encoded[i + 2];
+                
+                if (std::isxdigit(hex1) && std::isxdigit(hex2)) {
+                    std::stringstream ss;
+                    ss << std::hex << hex1 << hex2;
+                    int value;
+                    ss >> value;
+                    decoded += static_cast<char>(value);
+                    i += 2;
+                } else {
+                    decoded += encoded[i];
+                }
+            } else {
+                decoded += encoded[i];
+            }
+        }
+        
+        return decoded;
+    }
+    
+    // Normalize IP addresses from decimal/hex/octal formats to standard IPv4
+    std::string normalizeIP(const std::string_view& ip) {
+        std::string ipStr(ip);
+        
+        bool isPureNumber = true;
+        for (char c : ipStr) {
+            if (!std::isdigit(c)) {
+                isPureNumber = false;
+                break;
+            }
+        }
+        
+        if (isPureNumber && !ipStr.empty()) {
+            try {
+                unsigned long decimal = std::stoul(ipStr);
+                if (decimal <= 0xFFFFFFFF) {
+                    uint8_t octets[4];
+                    octets[0] = (decimal >> 24) & 0xFF;
+                    octets[1] = (decimal >> 16) & 0xFF;
+                    octets[2] = (decimal >> 8) & 0xFF;
+                    octets[3] = decimal & 0xFF;
+                    
+                    std::stringstream ss;
+                    ss << static_cast<int>(octets[0]) << "." 
+                       << static_cast<int>(octets[1]) << "."
+                       << static_cast<int>(octets[2]) << "."
+                       << static_cast<int>(octets[3]);
+                    return ss.str();
+                }
+            } catch (...) {
+            }
+        }
+        
+        if (ipStr.length() > 2 && ipStr.substr(0, 2) == "0x") {
+            try {
+                unsigned long hex = std::stoul(ipStr.substr(2), nullptr, 16);
+                if (hex <= 0xFFFFFFFF) {
+                    uint8_t octets[4];
+                    octets[0] = (hex >> 24) & 0xFF;
+                    octets[1] = (hex >> 16) & 0xFF;
+                    octets[2] = (hex >> 8) & 0xFF;
+                    octets[3] = hex & 0xFF;
+                    
+                    std::stringstream ss;
+                    ss << static_cast<int>(octets[0]) << "." 
+                       << static_cast<int>(octets[1]) << "."
+                       << static_cast<int>(octets[2]) << "."
+                       << static_cast<int>(octets[3]);
+                    return ss.str();
+                }
+            } catch (...) {
+            }
+        }
+        
+        size_t dotCount = 0;
+        for (char c : ipStr) {
+            if (c == '.') dotCount++;
+        }
+        
+        if (dotCount == 3) {
+            std::string normalized;
+            size_t start = 0;
+            bool allValid = true;
+            
+            for (int i = 0; i < 4; i++) {
+                size_t dotPos = (i < 3) ? ipStr.find('.', start) : std::string::npos;
+                size_t end = (dotPos != std::string::npos) ? dotPos : ipStr.length();
+                
+                if (end <= start) {
+                    allValid = false;
+                    break;
+                }
+                
+                std::string octetStr(ipStr.substr(start, end - start));
+                int octet = -1;
+                
+                if (octetStr.length() > 1 && octetStr[0] == '0' && std::isdigit(octetStr[1])) {
+                    try {
+                        octet = std::stoi(octetStr, nullptr, 8);
+                    } catch (...) {}
+                } else if (octetStr.length() > 2 && octetStr.substr(0, 2) == "0x") {
+                    try {
+                        octet = std::stoi(octetStr.substr(2), nullptr, 16);
+                    } catch (...) {}
+                } else {
+                    try {
+                        octet = std::stoi(octetStr);
+                    } catch (...) {}
+                }
+                
+                if (octet < 0 || octet > 255) {
+                    allValid = false;
+                    break;
+                }
+                
+                if (i > 0) normalized += ".";
+                normalized += std::to_string(octet);
+                
+                start = end + 1;
+            }
+            
+            if (allValid) {
+                return normalized;
+            }
+        }
+        
+        return ipStr;
+    }
+    
+    // Extract host from URL, handling userinfo and edge cases
+    std::string extractHost(const std::string_view& url, size_t schemeEnd) {
+        size_t pathStart = url.find_first_of("/?#", schemeEnd);
+        std::string_view authority = (pathStart != std::string::npos) 
+            ? url.substr(schemeEnd, pathStart - schemeEnd)
+            : url.substr(schemeEnd);
+        
+        size_t atPos = authority.find('@');
+        std::string_view hostPart = (atPos != std::string::npos) 
+            ? authority.substr(atPos + 1)
+            : authority;
+        
+        std::string host;
+        if (!hostPart.empty() && hostPart[0] == '[') {
+            size_t bracketEnd = hostPart.find(']');
+            if (bracketEnd != std::string::npos) {
+                host = std::string(hostPart.substr(0, bracketEnd + 1));
+            } else {
+                host = std::string(hostPart);
+            }
+        } else {
+            size_t portStart = hostPart.find(':');
+            host = (portStart != std::string::npos) 
+                ? std::string(hostPart.substr(0, portStart))
+                : std::string(hostPart);
+        }
+        
+        return host;
+    }
+    
+    // Helper function to parse IPv4 address and return octets
+    // Returns true if valid IPv4, false otherwise
+    bool parseIPv4(const std::string_view& host, uint8_t octets[4]) {
+        if (host.empty() || host.length() > 15) {
+            return false;
+        }
+        
+        size_t start = 0;
+        for (int i = 0; i < 4; i++) {
+            size_t dotPos = (i < 3) ? host.find('.', start) : std::string_view::npos;
+            size_t end = (dotPos != std::string_view::npos) ? dotPos : host.length();
+            
+            if (end == start || end - start > 3) {
+                return false;
+            }
+            
+            std::string octetStr(host.substr(start, end - start));
+            try {
+                int octet = std::stoi(octetStr);
+                if (octet < 0 || octet > 255) {
+                    return false;
+                }
+                octets[i] = static_cast<uint8_t>(octet);
+            } catch (...) {
+                return false;
+            }
+            
+            start = end + 1;
+        }
+        
+        return true;
+    }
+    
+    // Check if IPv4 address is in a blocked range
+    bool isIPv4Blocked(const std::string_view& host) {
+        uint8_t octets[4];
+        if (!parseIPv4(host, octets)) {
+            return false; // Not a valid IPv4, will be checked as hostname
+        }
+        
+        // Block 0.0.0.0/8 (0.0.0.0 to 0.255.255.255)
+        if (octets[0] == 0) {
+            return true;
+        }
+        
+        // Block 127.0.0.0/8 (127.0.0.0 to 127.255.255.255)
+        if (octets[0] == 127) {
+            return true;
+        }
+        
+        // Block 10.0.0.0/8 (10.0.0.0 to 10.255.255.255)
+        if (octets[0] == 10) {
+            return true;
+        }
+        
+        // Block 172.16.0.0/12 (172.16.0.0 to 172.31.255.255)
+        if (octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31) {
+            return true;
+        }
+        
+        // Block 192.168.0.0/16 (192.168.0.0 to 192.168.255.255)
+        if (octets[0] == 192 && octets[1] == 168) {
+            return true;
+        }
+        
+        // Block 169.254.0.0/16 (169.254.0.0 to 169.254.255.255)
+        if (octets[0] == 169 && octets[1] == 254) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    // Only allow IPv6 addresses in 2000::/3 range
+    bool isIPv6Allowed(const std::string_view& host) {
+        std::string_view ipv6 = host;
+        if (ipv6.length() >= 2 && ipv6[0] == '[' && ipv6[ipv6.length() - 1] == ']') {
+            ipv6 = ipv6.substr(1, ipv6.length() - 2);
+        }
+        
+        bool hasColon = false;
+        for (char c : ipv6) {
+            if (c == ':') {
+                hasColon = true;
+            } else if (!std::isxdigit(c) && c != '.') {
+                return false;
+            }
+        }
+        
+        if (!hasColon) {
+            return false;
+        }
+        
+        size_t ipv4MappedPos = ipv6.find("::ffff:");
+        if (ipv4MappedPos != std::string_view::npos) {
+            size_t ipv4Start = ipv4MappedPos + 7;
+            if (ipv4Start < ipv6.length()) {
+                std::string_view ipv4Part = ipv6.substr(ipv4Start);
+                size_t ipv4End = ipv4Part.find_first_of(":/");
+                if (ipv4End != std::string_view::npos) {
+                    ipv4Part = ipv4Part.substr(0, ipv4End);
+                }
+                if (isIPv4Blocked(ipv4Part)) {
+                    return false;
+                }
+            }
+        }
+        
+        size_t firstHexStart = 0;
+        
+        if (ipv6.length() >= 2 && ipv6[0] == ':' && ipv6[1] == ':') {
+            firstHexStart = 2;
+            while (firstHexStart < ipv6.length() && ipv6[firstHexStart] == ':') {
+                firstHexStart++;
+            }
+            
+            if (firstHexStart >= ipv6.length()) {
+                return false;
+            }
+        } else {
+            while (firstHexStart < ipv6.length() && (ipv6[firstHexStart] == ':' || !std::isxdigit(ipv6[firstHexStart]))) {
+                firstHexStart++;
+            }
+        }
+        
+        if (firstHexStart >= ipv6.length()) {
+            return false;
+        }
+        
+        size_t firstGroupEnd = firstHexStart;
+        while (firstGroupEnd < ipv6.length() && std::isxdigit(ipv6[firstGroupEnd])) {
+            firstGroupEnd++;
+        }
+        
+        if (firstGroupEnd == firstHexStart) {
+            return false;
+        }
+        
+        char firstHex = std::tolower(ipv6[firstHexStart]);
+        if (firstHex != '2' && firstHex != '3') {
+            return false;
+        }
+        
+        return true;
+    }
+}
+
 bool HTTPRequestManagerUtils::isUrlAllowed(const StringBox& url) {
     if (url.isEmpty()) {
         return false;
@@ -43,9 +361,11 @@ bool HTTPRequestManagerUtils::isUrlAllowed(const StringBox& url) {
     
     std::string_view urlView = url.toStringView();
     
+    std::string decodedUrl = urlDecode(urlView);
+    
     std::string urlLower;
-    urlLower.reserve(urlView.size());
-    std::transform(urlView.begin(), urlView.end(), std::back_inserter(urlLower),
+    urlLower.reserve(decodedUrl.size());
+    std::transform(decodedUrl.begin(), decodedUrl.end(), std::back_inserter(urlLower),
                    [](unsigned char c) { return std::tolower(c); });
     std::string_view urlLowerView(urlLower);
     
@@ -59,53 +379,44 @@ bool HTTPRequestManagerUtils::isUrlAllowed(const StringBox& url) {
     }
     schemeEnd += 3;
     
-    size_t hostEnd = urlLowerView.find_first_of("/?#", schemeEnd);
-    std::string_view hostPart = hostEnd == std::string_view::npos 
-        ? urlLowerView.substr(schemeEnd)
-        : urlLowerView.substr(schemeEnd, hostEnd - schemeEnd);
+    std::string hostStr = extractHost(urlLowerView, schemeEnd);
     
-    size_t portStart = hostPart.find(':');
-    if (portStart != std::string_view::npos) {
-        hostPart = hostPart.substr(0, portStart);
-    }
+    std::string normalizedHost = normalizeIP(hostStr);
     
-    if (hostPart == "localhost" ||
-        hostPart == "127.0.0.1" ||
-        hostPart == "::1" ||
-        hostPart == "[::1]" ||
-        hostPart.find("localhost") == 0) {
+    std::string_view hostWithoutPort = normalizedHost;
+    
+    std::string hostLower = normalizedHost;
+    std::transform(hostLower.begin(), hostLower.end(), hostLower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    
+    if (hostLower == "localhost" || hostLower.find("localhost") == 0) {
         return false;
     }
     
-    if (hostPart == "metadata.google.internal" ||
-        hostPart == "169.254.169.254") {
+    std::string originalHostLower = hostStr;
+    std::transform(originalHostLower.begin(), originalHostLower.end(), originalHostLower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (originalHostLower == "localhost" || originalHostLower.find("localhost") == 0) {
         return false;
     }
     
-    if (hostPart.length() >= 3 && hostPart.substr(0, 3) == "10.") {
-        if (hostPart.length() > 3 && std::isdigit(hostPart[3])) {
+    if (hostLower == "metadata.google.internal" || originalHostLower == "metadata.google.internal") {
+        return false;
+    }
+    
+    if (isIPv4Blocked(hostWithoutPort)) {
+        return false;
+    }
+    
+    if (normalizedHost != hostStr && isIPv4Blocked(hostStr)) {
+        return false;
+    }
+    
+    if (hostWithoutPort.find(':') != std::string_view::npos || 
+        (!hostWithoutPort.empty() && hostWithoutPort[0] == '[')) {
+        if (!isIPv6Allowed(hostWithoutPort)) {
             return false;
         }
-    }
-    
-    if (hostPart.length() >= 7 && hostPart.substr(0, 4) == "172.") {
-        if (hostPart.length() > 4 && std::isdigit(hostPart[4])) {
-            size_t secondDot = hostPart.find('.', 4);
-            if (secondDot != std::string_view::npos && secondDot > 4) {
-                std::string secondOctetStr(hostPart.substr(4, secondDot - 4));
-                try {
-                    int secondOctet = std::stoi(secondOctetStr);
-                    if (secondOctet >= 16 && secondOctet <= 31) {
-                        return false;
-                    }
-                } catch (...) {
-                }
-            }
-        }
-    }
-    
-    if (hostPart.length() >= 8 && hostPart.substr(0, 8) == "192.168.") {
-        return false;
     }
     
     return true;

--- a/valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.cpp
+++ b/valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.cpp
@@ -7,6 +7,10 @@
 
 #include "valdi/runtime/Utils/HTTPRequestManagerUtils.hpp"
 #include "valdi_core/cpp/Utils/StringCache.hpp"
+#include <string_view>
+#include <algorithm>
+#include <cctype>
+#include <string>
 
 namespace Valdi {
 
@@ -30,6 +34,90 @@ private:
 std::shared_ptr<snap::valdi_core::HTTPRequestManagerCompletion> HTTPRequestManagerUtils::makeRequestCompletion(
     Function<void(Result<snap::valdi_core::HTTPResponse>)> function) { // NOLINT(performance-unnecessary-value-param)
     return Valdi::makeShared<HTTPRequestManagerCompletionWithFunction>(std::move(function));
+}
+
+bool HTTPRequestManagerUtils::isUrlAllowed(const StringBox& url) {
+    if (url.isEmpty()) {
+        return false;
+    }
+    
+    std::string_view urlView = url.toStringView();
+    
+    // Convert to lowercase for case-insensitive comparison
+    std::string urlLower;
+    urlLower.reserve(urlView.size());
+    std::transform(urlView.begin(), urlView.end(), std::back_inserter(urlLower),
+                   [](unsigned char c) { return std::tolower(c); });
+    std::string_view urlLowerView(urlLower);
+    
+    // Only allow http:// and https:// schemes
+    if (urlLowerView.find("http://") != 0 && urlLowerView.find("https://") != 0) {
+        return false;
+    }
+    
+    // Extract host part (between :// and / or end of string)
+    size_t schemeEnd = urlLowerView.find("://");
+    if (schemeEnd == std::string_view::npos) {
+        return false;
+    }
+    schemeEnd += 3; // Skip "://"
+    
+    size_t hostEnd = urlLowerView.find_first_of("/?#", schemeEnd);
+    std::string_view hostPart = hostEnd == std::string_view::npos 
+        ? urlLowerView.substr(schemeEnd)
+        : urlLowerView.substr(schemeEnd, hostEnd - schemeEnd);
+    
+    // Remove port if present
+    size_t portStart = hostPart.find(':');
+    if (portStart != std::string_view::npos) {
+        hostPart = hostPart.substr(0, portStart);
+    }
+    
+    // Block localhost and loopback addresses
+    if (hostPart == "localhost" ||
+        hostPart == "127.0.0.1" ||
+        hostPart == "::1" ||
+        hostPart == "[::1]" ||
+        hostPart.find("localhost") == 0) {
+        return false;
+    }
+    
+    // Block cloud metadata service hostnames
+    if (hostPart == "metadata.google.internal" ||
+        hostPart == "169.254.169.254") {
+        return false;
+    }
+    
+    // Block private IP ranges - check if host starts with private IP prefixes
+    if (hostPart.length() >= 3 && hostPart.substr(0, 3) == "10.") {
+        if (hostPart.length() > 3 && std::isdigit(hostPart[3])) {
+            return false;
+        }
+    }
+    
+    // 172.16.0.0/12 (172.16.0.0 to 172.31.255.255)
+    if (hostPart.length() >= 7 && hostPart.substr(0, 4) == "172.") {
+        // Check if second octet is 16-31
+        if (hostPart.length() > 4 && std::isdigit(hostPart[4])) {
+            size_t secondDot = hostPart.find('.', 4);
+            if (secondDot != std::string_view::npos && secondDot > 4) {
+                std::string secondOctetStr(hostPart.substr(4, secondDot - 4));
+                try {
+                    int secondOctet = std::stoi(secondOctetStr);
+                    if (secondOctet >= 16 && secondOctet <= 31) {
+                        return false;
+                    }
+                } catch (...) {
+                }
+            }
+        }
+    }
+    
+    if (hostPart.length() >= 8 && hostPart.substr(0, 8) == "192.168.") {
+        return false;
+    }
+    
+    return true;
 }
 
 } // namespace Valdi

--- a/valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.hpp
+++ b/valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.hpp
@@ -11,6 +11,7 @@
 #include "valdi_core/HTTPResponse.hpp"
 #include "valdi_core/cpp/Utils/Function.hpp"
 #include "valdi_core/cpp/Utils/Result.hpp"
+#include "valdi_core/cpp/Utils/StringBox.hpp"
 
 namespace Valdi {
 
@@ -18,6 +19,12 @@ class HTTPRequestManagerUtils {
 public:
     static std::shared_ptr<snap::valdi_core::HTTPRequestManagerCompletion> makeRequestCompletion(
         Function<void(Result<snap::valdi_core::HTTPResponse>)> function);
+    
+    /**
+     * Validates that a URL is safe to request, blocking SSRF attack vectors.
+     * Returns false if the URL should be blocked (localhost, private IPs, cloud metadata, etc.)
+     */
+    static bool isUrlAllowed(const StringBox& url);
 };
 
 } // namespace Valdi


### PR DESCRIPTION
## Summary

This PR fixes a **Server-Side Request Forgery (SSRF)** vulnerability in Valdi's HTTP client implementation. The vulnerability allows applications built with Valdi to make HTTP requests to arbitrary URLs, including internal/localhost services, cloud metadata endpoints, and private network resources, without any URL validation.

## Vulnerability Details

**Type:** Server-Side Request Forgery (SSRF)  
**Severity:** High  
**Component:** `HTTPRequestManagerModuleFactory.cpp`

### Root Cause

The vulnerability exists because user-provided URLs from JavaScript/TypeScript are passed directly to native HTTP request managers without any validation. The vulnerable code flow:

1. **TypeScript Layer** (`HTTPClient.ts`): User input flows into `HTTPClient.perform()` method
   - URL is constructed via `makeURL()` function: [`HTTPClient.ts:7-22`](https://github.com/Snapchat/Valdi/blob/f34a5a191ef0d2485e780a3d5fa21f002244dadd/src/valdi_modules/src/valdi/valdi_http/src/HTTPClient.ts#L7-L22)
   - No validation is performed on the URL

2. **Native Module Binding** (`HTTPRequestManagerModuleFactory.cpp:50-51`): URL extracted directly:
   ```cpp
   auto url = requestObject.getMapValue("url").toStringBox();
   ```

3. **Request Execution** (`HTTPRequestManagerModuleFactory.cpp:94-97`): URL passed directly to platform HTTP libraries:
   ```cpp
   auto cancellable = requestManager->performRequest(
       snap::valdi_core::HTTPRequest(std::move(url), ...), ...);
   ```

### Missing Security Controls

The framework lacks:
- **Scheme validation** - Allows non-HTTP/HTTPS protocols
- **IP address filtering** - Allows localhost, private IPs, cloud metadata IPs
- **Hostname validation** - No allowlist/blocklist mechanism
- **URL sanitization** - No parsing or normalization

### Impact

**Critical Impact: Cloud Metadata Service Access**
- If a Valdi application runs on cloud infrastructure (AWS EC2, GCP, Azure), attackers can access metadata services
- Example: `http://169.254.169.254/latest/meta-data/iam/security-credentials/`
- **Result:** Complete cloud account compromise, data breach, resource hijacking

**High Impact: Internal Service Access**
- Attackers can access internal services accessible from the device running the Valdi application
- Localhost services: `http://localhost:8080`, `http://127.0.0.1:3306`
- Internal network services: `http://192.168.1.1/admin`, `http://10.0.0.1:8080`
- **Result:** Sensitive data exposure, unauthorized access to internal systems

**Medium-High Impact: Network Reconnaissance**
- Attackers can perform internal network scanning and service discovery
- **Result:** Enables attackers to map internal networks and identify additional attack targets

### Affected Applications

**All applications built with Valdi that use the `valdi_http` module are vulnerable**, including:
- Production applications at Snap (Valdi has been used in production for 8 years)
- Any third-party applications using Valdi
- Enterprise applications deployed on cloud infrastructure
- Applications running on devices with access to internal networks

## Solution

This PR adds URL validation to prevent SSRF attacks by:

1. **Adding `isUrlAllowed()` function** in `HTTPRequestManagerUtils` that validates URLs before requests are made
2. **Blocking dangerous URLs:**
   - Localhost and loopback addresses (`localhost`, `127.0.0.1`, `::1`)
   - Private IP ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
   - Cloud metadata service IPs (`169.254.169.254`, `metadata.google.internal`)
   - Non-HTTP/HTTPS schemes (only allows `http://` and `https://`)

3. **Integrating validation** into `HTTPRequestManagerModuleFactory::loadModule()` to validate URLs before making requests

## Changes Made

### Files Modified

1. **`valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.hpp`**
   - Added `isUrlAllowed()` static method declaration
   - Added include for `StringBox`

2. **`valdi/src/valdi/runtime/Utils/HTTPRequestManagerUtils.cpp`**
   - Implemented `isUrlAllowed()` function with comprehensive URL validation
   - Extracts host part from URL
   - Validates scheme, hostname, and IP addresses
   - Blocks localhost, private IPs, and cloud metadata endpoints

3. **`src/valdi_modules/src/cpp/valdi_http/HTTPRequestManagerModuleFactory.cpp`**
   - Added URL validation check after URL extraction (line 51)
   - Returns error if URL is blocked
   - Prevents SSRF attacks before requests are made

### Code Changes

**Before (Vulnerable):**
```cpp
auto url = requestObject.getMapValue("url").toStringBox();
// No validation - URL used directly
auto cancellable = requestManager->performRequest(...);
```

**After (Fixed):**
```cpp
auto url = requestObject.getMapValue("url").toStringBox();

// Validate URL to prevent SSRF attacks
if (!HTTPRequestManagerUtils::isUrlAllowed(url)) {
    callContext.getExceptionTracker().onError(
        Error("URL not allowed: blocked localhost, private IP, or cloud metadata"));
    return Value::undefined();
}

auto cancellable = requestManager->performRequest(...);
```

## Testing

The validation function blocks:
- ✅ `http://localhost:8080` - Blocked
- ✅ `http://127.0.0.1:3306` - Blocked
- ✅ `http://192.168.1.1/admin` - Blocked
- ✅ `http://10.0.0.1:8080` - Blocked
- ✅ `http://169.254.169.254/latest/meta-data/` - Blocked
- ✅ `http://metadata.google.internal/...` - Blocked
- ✅ `file:///etc/passwd` - Blocked (non-HTTP scheme)
- ✅ `https://example.com` - Allowed
- ✅ `http://api.example.com/v1/data` - Allowed

## Security Considerations

- **Backward Compatibility:** The fix maintains backward compatibility for legitimate use cases (public HTTP/HTTPS URLs)
- **Performance:** URL validation is lightweight and performed before network requests
- **False Positives:** The validation is designed to minimize false positives by properly parsing the host part of URLs

## References

- **OWASP SSRF:** https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
- **CWE-918:** https://cwe.mitre.org/data/definitions/918.html
- **Vulnerable Code:** [`HTTPRequestManagerModuleFactory.cpp:50-97`](https://github.com/Snapchat/Valdi/blob/f34a5a191ef0d2485e780a3d5fa21f002244dadd/src/valdi_modules/src/cpp/valdi_http/HTTPRequestManagerModuleFactory.cpp#L50-L97)

## Responsible Disclosure

This vulnerability was discovered during security research. This PR provides a fix while maintaining backward compatibility for legitimate use cases. I reported through hackerone and I was asked to open a PR for this by [bugtriage-jay](https://hackerone.com/bugtriage-jay) as this is not covered under Snapchat's bug bounty scope.

---

**Note:** This is a security fix addressing a framework-level vulnerability that affects all Valdi applications using the HTTP client.

Fixes #63 
