### PR TITLE
lib/utils/crypto: use 32 byte key size instead of 16

### DIFF
--- a/libs/utils/src/utils/crypto/AesEncryptor.cpp
+++ b/libs/utils/src/utils/crypto/AesEncryptor.cpp
@@ -12,13 +12,13 @@ namespace snap::utils::crypto {
 constexpr auto kTag = "[utils][AesEncryptor]";
 
 AesEncryptor::AesEncryptor(const AesEncryptor::Key& key, const AesEncryptor::Iv& iv)
-    : _cipher(EVP_aead_aes_128_gcm()), _key(key), _iv(iv) {
+    : _cipher(EVP_aead_aes_256_gcm()), _key(key), _iv(iv) {
     SC_ASSERT(_key.size() == EVP_AEAD_key_length(_cipher));
     SC_ASSERT(_iv.size() == EVP_AEAD_nonce_length(_cipher));
 }
 
 AesEncryptor::AesEncryptor(const bssl::Span<uint8_t>& key, const bssl::Span<uint8_t>& iv)
-    : _cipher(EVP_aead_aes_128_gcm()) {
+    : _cipher(EVP_aead_aes_256_gcm()) {
     SC_ASSERT(_key.size() == EVP_AEAD_key_length(_cipher));
     SC_ASSERT(_iv.size() == EVP_AEAD_nonce_length(_cipher));
     std::copy(key.begin(), key.end(), _key.begin());
@@ -26,7 +26,7 @@ AesEncryptor::AesEncryptor(const bssl::Span<uint8_t>& key, const bssl::Span<uint
 }
 
 AesEncryptor::AesEncryptor(const std::vector<uint8_t>& key, const std::vector<uint8_t>& iv)
-    : _cipher(EVP_aead_aes_128_gcm()) {
+    : _cipher(EVP_aead_aes_256_gcm()) {
     SC_ASSERT(_key.size() == EVP_AEAD_key_length(_cipher));
     SC_ASSERT(_iv.size() == EVP_AEAD_nonce_length(_cipher));
     std::copy(key.begin(), key.end(), _key.begin());

--- a/libs/utils/src/utils/crypto/AesEncryptor.hpp
+++ b/libs/utils/src/utils/crypto/AesEncryptor.hpp
@@ -16,7 +16,7 @@ class Span;
 namespace snap::utils::crypto {
 
 /**
- * Convenience class for encrypting/decrypting bytes using AES-128-GCM (128-bit keys and 96-bit nonce/iv).
+ * Convenience class for encrypting/decrypting bytes using AES-256-GCM (256-bit keys and 96-bit nonce/iv).
  * Once initialized with a key, this class should only be used for one round of encryption.
  * Keys and IVs MUST be generated with secure randomness. See utils::generateSecureRandomBytes.
  * DO NOT encrypt more than once with the same key and IV.
@@ -32,7 +32,7 @@ namespace snap::utils::crypto {
  */
 class AesEncryptor {
 public:
-    using Key = std::array<uint8_t, 16>;
+    using Key = std::array<uint8_t, 32>;
     using Iv = std::array<uint8_t, 12>;
 
     // TODO: Allow re-use of keys and setting the IV.


### PR DESCRIPTION
This is done to improve security.