### PR TITLE
fix: Fix rendering bug in Conversation.tsx by replacing forEach with map

### DIFF
--- a/apps/valdi_gpt/src/valdi/conversation/src/Conversation.tsx
+++ b/apps/valdi_gpt/src/valdi/conversation/src/Conversation.tsx
@@ -4,9 +4,9 @@ import { Message, MesssageViewModel } from './Message';
 import { InputBar } from './InputBar';
 import { AiService, GptRole } from '../../ai_service/src/AiService';
 
-export interface ConversationViewModel {}
+export interface ConversationViewModel { }
 
-export interface ConversationContext {}
+export interface ConversationContext { }
 
 interface ConversationState {
   results: MesssageViewModel[];
@@ -29,7 +29,7 @@ export class Conversation extends StatefulComponent<ConversationViewModel, Conve
       <InputBar onSubmit={this.onSubmit} />
       <scroll>
         <view flexDirection="column-reverse" paddingTop={20}>
-          {[...this.state!.results].reverse().forEach(message => (
+          {[...this.state!.results].reverse().map(message => (
             <Message text={message.text} outbound={message.outbound} />
           ))}
         </view>


### PR DESCRIPTION
## Summary
Fixes a critical bug in [Conversation.tsx](cci:7://file:///home/alonexe/Documents/Valdi-2/apps/valdi_gpt/src/valdi/conversation/src/Conversation.tsx:0:0-0:0) where chat messages were failing to render.

## Problem
The message list was being iterated using `.forEach()`, which returns `undefined` and produces no output in the JSX. This caused the chat interface to appear empty even when messages existed in the state.

## Solution
Replaced `.forEach()` with `.map()` to correctly return an array of `<Message />` components for rendering.

## Testing
- Verified that the syntax now correctly constructs a list of React/Valdi elements.
- Confirmed that `map` is the standard and correct patterns for list rendering in this context.