### PR TITLE
fix: escape string literals in GenerateIds.ts code generation

### DIFF
--- a/compiler/companion/src/GenerateIds.spec.ts
+++ b/compiler/companion/src/GenerateIds.spec.ts
@@ -102,4 +102,24 @@ NS_ASSUME_NONNULL_END
 `,
     );
   });
+
+  it('escapes double quotes in ObjC impl when module name contains them', () => {
+    const iosImpl = generateIds('hello"world', '"SCHelloWorld/Ids.h"', TEST_ID_FILES).ios.impl;
+    expect(iosImpl).toContain('return @"hello\\"world/my_first_id";');
+  });
+
+  it('escapes backslashes in ObjC impl when module name contains them', () => {
+    const iosImpl = generateIds('hello\\world', '"SCHelloWorld/Ids.h"', TEST_ID_FILES).ios.impl;
+    expect(iosImpl).toContain('return @"hello\\\\world/my_first_id";');
+  });
+
+  it('escapes single quotes in JS impl when module name contains them', () => {
+    const jsImpl = generateIds("hello'world", '"SCHelloWorld/Ids.h"', TEST_ID_FILES).typescript.implementation;
+    expect(jsImpl).toContain("myFirstId: () => 'hello\\'world/my_first_id',");
+  });
+
+  it('escapes backslashes in JS impl when module name contains them', () => {
+    const jsImpl = generateIds('hello\\world', '"SCHelloWorld/Ids.h"', TEST_ID_FILES).typescript.implementation;
+    expect(jsImpl).toContain("myFirstId: () => 'hello\\\\world/my_first_id',");
+  });
 });

--- a/compiler/companion/src/GenerateIds.ts
+++ b/compiler/companion/src/GenerateIds.ts
@@ -38,6 +38,24 @@ interface Id {
   description?: string;
 }
 
+function escapeObjCString(str: string): string {
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
+function escapeJSSingleQuotedString(str: string): string {
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
 function parseIds(moduleName: string, fileContent: string): Id[] {
   const idsYaml = yaml.load(fileContent.toString()) as IdsYaml;
 
@@ -122,7 +140,7 @@ function generateIOSIds(ids: Id[], iosHeaderImportPath: string): ObjectiveCFile 
     header.append(`extern ${functionSignature};\n`);
     impl.append(`${functionSignature} {\n`);
     impl.withIndentation('    ', () => {
-      impl.append(`return @"${id.identifier}";\n`);
+      impl.append(`return @"${escapeObjCString(id.identifier)}";\n`);
     });
     impl.append('}\n');
   }
@@ -158,7 +176,7 @@ function generateTypeScriptIds(ids: Id[]): TypeScriptFile {
     }
     definition.append(`static ${id.name}(): string;\n`);
 
-    implementation.append(`${id.name}: () => '${id.identifier}',\n`);
+    implementation.append(`${id.name}: () => '${escapeJSSingleQuotedString(id.identifier)}',\n`);
   }
 
   definition.endIndent();


### PR DESCRIPTION
## Description

Module names containing `"`, `'`, or `\` were embedded directly into generated Objective-C and TypeScript/JS code without escaping, producing syntactically broken output — the same class of bug as the recently fixed IR escaping issue.

Two helper functions are added and applied at the two affected sites:
- `escapeObjCString` — escapes `\`, `"`, `\n`, `\r`, `\t` for ObjC `@"..."` string literals (line 120)
- `escapeJSSingleQuotedString` — escapes `\`, `'`, `\n`, `\r`, `\t` for JS `'...'` string literals (line 153)

`StringEscape.ts` (`toCString`) was intentionally not reused — it targets C code with different delimiter conventions.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tests pass locally (`npm run test` in `compiler/companion`)
- [x] Added/updated tests for changes (if applicable)
- [ ] Tested on multiple platforms (iOS/Android/Web/macOS as applicable)
- [ ] Manual testing performed (describe below)

### Testing Details

Added 4 regression tests in `GenerateIds.spec.ts` covering double-quote and backslash escaping for both ObjC and JS output (9 tests total, all passing). The pre-existing `SQLiteCompilationCache` test failure is a pre-existing environment issue (native binary compiled against a different Node.js version) and is unrelated to this change.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in description)
- [x] Commit messages follow [conventional format](../CONTRIBUTING.md#commit-messages)
- [x] No secrets, API keys, or internal URLs included

## Related Issues
<!-- Link related issues using: Closes #(issue), Fixes #(issue), Relates to #(issue) -->

## Additional Context

Prettier (`npm run format`) was run as part of validation and produced no changes to the modified files.