### PR TITLE
Switch npm publish to OIDC trusted publishers

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -116,6 +116,7 @@ jobs:
     needs: [detect-changes, test-cli, test-cli-build]
     if: needs.detect-changes.outputs.cli == 'true'
     runs-on: ubuntu-latest
+    environment: npm-publish
     defaults:
       run:
         working-directory: npm_modules/cli
@@ -136,14 +137,13 @@ jobs:
         run: npm run build
 
       - name: Publish @snap/valdi to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
 
   publish-eslint-plugin:
     needs: detect-changes
     if: needs.detect-changes.outputs.eslint-plugin == 'true'
     runs-on: ubuntu-latest
+    environment: npm-publish
     defaults:
       run:
         working-directory: npm_modules/eslint-plugin-valdi
@@ -164,7 +164,5 @@ jobs:
         run: npm run build
 
       - name: Publish @snap/eslint-plugin-valdi to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
 


### PR DESCRIPTION
## Summary
- Remove `NPM_TOKEN` secret dependency from both publish jobs
- Add `--provenance` flag to `npm publish` for OIDC-based authentication
- Add `environment: npm-publish` to both publish jobs (required for OIDC token claims)

## Setup required before merging
1. **npmjs.com** — configure trusted publisher on both `@snap/valdi` and `@snap/eslint-plugin-valdi`:
   - Repository owner: `Snapchat`
   - Repository name: `Valdi`
   - Workflow filename: `publish-npm.yml`
   - Environment: `npm-publish`
2. **github.com/Snapchat/Valdi** — create an environment named `npm-publish` (Settings > Environments)

## Test plan
- [ ] Create `npm-publish` environment on the repo
- [ ] Configure trusted publisher on npmjs.com for `@snap/valdi`
- [ ] Configure trusted publisher on npmjs.com for `@snap/eslint-plugin-valdi`
- [ ] Merge and trigger a workflow_dispatch run to verify publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)