### PR TITLE
Cherry-pick Android bootstrap fix for beta-0.1.1

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,7 +61,6 @@ build --tool_java_runtime_version=remotejdk_17
 build --flag_alias=snap_flavor=@snap_platforms//flavors:snap_flavor
 build --snap_flavor=client_development
 
-build --android_sdk=@androidsdk//:sdk
 build --define=android_dexmerger_tool=d8_dexmerger
 build --define=android_incremental_dexing_tool=d8_dexbuilder
 build --define=android_standalone_dexing_tool=d8_compat_dx

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -67,8 +67,9 @@ single_version_override(
     version = "1.9.5",
     patches = [
         "@valdi//registry/modules/rules_kotlin/1.9.0/patches:rules_kotlin.patch",
+        "@valdi//registry/modules/rules_kotlin/1.9.0/patches:rules_kotlin_hermetic_sdk.patch",
         "@valdi//registry/modules/rules_kotlin/1.9.0/patches:rules_kotlin_android_sdk.patch",
-        "@valdi//registry/modules/rules_kotlin/1.9.0/patches:rules_kotlin_module_bzl.patch",
+        "@valdi//registry/modules/rules_kotlin/1.9.0/patches:rules_kotlin_module_bzl_v195.patch",
     ],
 )
 bazel_dep(name = "rules_jvm_external", version = "6.2")

--- a/npm_modules/cli/.metadata/.bazelrc.template
+++ b/npm_modules/cli/.metadata/.bazelrc.template
@@ -17,7 +17,7 @@ common --incompatible_java_common_parameters=false
 # Flags for compilation
 common --define enable_web=true
 
-build --tool_java_language_version=11
+build --tool_java_language_version=17
 build --java_language_version=11
 
 ## Disable sandboxing for macs, both laptops and in CI; the performance hit is much too high.

--- a/npm_modules/cli/.metadata/MODULE.bazel.template
+++ b/npm_modules/cli/.metadata/MODULE.bazel.template
@@ -55,6 +55,98 @@ use_repo(valdi_toolchains, "local_config_apple_cc_toolchains", "local_config_app
 register_toolchains("@local_config_apple_cc_toolchains//:all")
 register_toolchains("@llvm_toolchain//:all")
 
+# -- Android dependencies ----------------------------------------------------
+bazel_dep(name = "rules_java", version = "7.4.0")
+bazel_dep(name = "rules_android", version = "0.6.5")
+bazel_dep(name = "rules_android_ndk", version = "0.1.3")
+
+remote_android_extensions = use_extension(
+    "@rules_android//bzlmod_extensions:android_extensions.bzl",
+    "remote_android_tools_extensions",
+)
+use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
+
+hermetic_android_sdk_extension = use_extension("@valdi//bzl:hermetic_android_sdk.bzl", "hermetic_android_sdk_extension")
+hermetic_android_sdk_extension.configure(
+    api_level = 36,
+    build_tools_version = "34.0.0",
+)
+use_repo(hermetic_android_sdk_extension, "androidsdk")
+
+register_toolchains(
+    "@rules_android//toolchains/android:all",
+    "@rules_android//toolchains/android_sdk:all",
+)
+register_toolchains("@androidsdk//:sdk-toolchain", "@androidsdk//:all")
+
+hermetic_ndk_extension = use_extension("@valdi//bzl:hermetic_ndk.bzl", "hermetic_ndk_extension")
+use_repo(hermetic_ndk_extension, "androidndk")
+
+register_toolchains("@androidndk//:all")
+
+bazel_dep(name = "rules_kotlin", version = "1.9.0")
+single_version_override(module_name = "rules_kotlin", version = "1.9.0")
+bazel_dep(name = "rules_jvm_external", version = "6.2")
+
+# -- Maven (Android) ---------------------------------------------------------
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+
+maven.install(
+    name = "android_mvn",
+    artifacts = [
+        "androidx.annotation:annotation:1.1.0",
+        "androidx.appcompat:appcompat:1.2.0",
+        "androidx.appcompat:appcompat-resources:1.2.0",
+        "androidx.collection:collection:1.1.0",
+        "androidx.constraintlayout:constraintlayout:2.1.4",
+        "androidx.core:core:1.6.0",
+        "androidx.customview:customview:1.1.0",
+        "androidx.dynamicanimation:dynamicanimation:1.0.0",
+        "androidx.fragment:fragment:1.1.0",
+        "androidx.interpolator:interpolator:1.0.0",
+        "androidx.lifecycle:lifecycle-common:2.2.0",
+        "androidx.lifecycle:lifecycle-process:2.2.0",
+        "androidx.lifecycle:lifecycle-viewmodel:2.2.0",
+        "androidx.recyclerview:recyclerview:1.2.1",
+        "androidx.test:core:1.5.0",
+        "androidx.test.ext:junit:1.1.3",
+        "androidx.test:monitor:1.5.0",
+        "androidx.test:runner:1.5.0",
+        "com.google.android.material:material:1.2.0",
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.code.gson:gson:2.8.6",
+        "com.google.protobuf.nano:protobuf-javanano:3.1.0",
+        "com.jakewharton.timber:timber:4.7.1",
+        "com.squareup.leakcanary:leakcanary-android:2.10",
+        "com.squareup.okhttp3:okhttp:4.9.0",
+        "com.squareup.okio:okio:2.10.0",
+        "io.reactivex.rxjava3:rxandroid:3.0.0",
+        "io.reactivex.rxjava3:rxjava:3.1.0",
+        "io.reactivex.rxjava3:rxkotlin:3.0.0",
+        "javax.inject:javax.inject:1",
+        "junit:junit:4.13.2",
+        "org.junit.jupiter:junit-jupiter-api:5.9.3",
+        "org.junit.jupiter:junit-jupiter-engine:5.9.3",
+        "org.junit.jupiter:junit-jupiter-params:5.9.3",
+        "org.junit.platform:junit-platform-console:1.9.2",
+        "org.junit.platform:junit-platform-launcher:1.9.2",
+        "org.junit.platform:junit-platform-reporting:1.9.2",
+        "org.junit.vintage:junit-vintage-engine:5.9.3",
+        "org.robolectric:android-all:10-robolectric-5803371",
+        "org.robolectric:annotations:4.10.3",
+        "org.robolectric:robolectric:4.10.3",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+    aar_import_bzl_label = "@rules_android//rules:rules.bzl",
+    use_starlark_android_rules = True,
+    version_conflict_policy = "pinned",
+)
+
+use_repo(maven, "android_mvn")
+
 # -- Version pins (must match Valdi's MODULE.bazel) ---------------------------
 single_version_override(module_name = "protobuf", version = "27.0")
 single_version_override(module_name = "rules_apple", version = "4.0.0")

--- a/npm_modules/cli/test/ValdiSmokeTest.ts
+++ b/npm_modules/cli/test/ValdiSmokeTest.ts
@@ -54,9 +54,9 @@ void describe('valdi ui app', () => {
       await lookForOutput({ stderr: [/Build completed successfully, \d+ total actions?/] }, task);
     });
 
-    void it('build android', { skip: true }, async () => {
+    void it('build android', async () => {
       const task = run('valdi', ['build', 'android']);
-      await lookForOutput({ stderr: [/Build completed successfully, \d+ total actions?/] }, task);
+      await lookForOutput({ stderr: [/Build completed successfully, \d+ total actions?/], idleTimeoutMs: 120_000 }, task);
     });
 
     void it('valdi doctor', async () => {

--- a/npm_modules/cli/test/helpers/AsyncHelpers.ts
+++ b/npm_modules/cli/test/helpers/AsyncHelpers.ts
@@ -46,10 +46,10 @@ export function timeoutOnIdle(ms = 30_000): [timeout: Promise<never>, touch: () 
  * Rejects if there are queries remaning after the
  */
 export function lookForOutput(
-  { stdout = [], stderr = [] }: { stdout?: (string | RegExp)[]; stderr?: (string | RegExp)[] },
+  { stdout = [], stderr = [], idleTimeoutMs }: { stdout?: (string | RegExp)[]; stderr?: (string | RegExp)[]; idleTimeoutMs?: number },
   subcommand: SubCommand,
 ): Promise<true> {
-  const [idleTimer, touch, complete] = timeoutOnIdle();
+  const [idleTimer, touch, complete] = timeoutOnIdle(idleTimeoutMs);
 
   const monitor = (requiredQueries: (string | RegExp)[]) => {
     let queries = requiredQueries.slice();

--- a/registry/modules/rules_kotlin/1.9.0/MODULE.bazel
+++ b/registry/modules/rules_kotlin/1.9.0/MODULE.bazel
@@ -10,8 +10,13 @@ bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_java", version = "6.4.0")
 bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "rules_cc", version = "0.0.8")
+bazel_dep(name = "rules_android", version = "0.6.5")
+bazel_dep(name = "rules_shell", version = "0.1.2")
 
-rules_kotlin_extensions = use_extension("//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")
+rules_kotlin_extensions = use_extension(
+    "//src/main/starlark/core/repositories:bzlmod_setup.bzl",
+    "rules_kotlin_extensions",
+)
 use_repo(
     rules_kotlin_extensions,
     "buildkite_config",
@@ -19,7 +24,6 @@ use_repo(
     "com_github_jetbrains_kotlin",
     "com_github_pinterest_ktlint",
     "kt_java_stub_template",
-    "rules_android",
 )
 
 register_toolchains("//kotlin/internal:default_toolchain")
@@ -27,6 +31,10 @@ register_toolchains("//kotlin/internal:default_toolchain")
 # TODO(bencodes) We should be able to remove this once rules_android has rolled out official Bzlmod support
 remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
 use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
+
+# Hermetic Android SDK — download the SDK so no local install is required
+hermetic_android_sdk = use_extension("//:bzl/hermetic_android_sdk.bzl", "hermetic_android_sdk_extension")
+use_repo(hermetic_android_sdk, "androidsdk")
 
 # Development dependencies
 # TODO(bencodes) A bunch of these dependencies need to be marked as dev_dependencies but before we can do that

--- a/registry/modules/rules_kotlin/1.9.0/patches/rules_kotlin_hermetic_sdk.patch
+++ b/registry/modules/rules_kotlin/1.9.0/patches/rules_kotlin_hermetic_sdk.patch
@@ -1,0 +1,94 @@
+--- /dev/null
++++ bzl/hermetic_android_sdk.bzl
+@@ -0,0 +1,91 @@
++# Hermetic Android SDK for rules_kotlin.  Downloads platform, build-tools, and
++# platform-tools from dl.google.com so no local SDK install is needed.
++
++_API_LEVEL = 36
++_BUILD_TOOLS_VERSION = "34.0.0"
++
++_PLATFORM_URL = "https://dl.google.com/android/repository/platform-36_r02.zip"
++_PLATFORM_SHA256 = "37607369a28c5b640b3a7998868d45898ebcb777565a0e85f9acf36f29631d2e"
++_PLATFORM_STRIP_PREFIX = "android-36"
++
++_BUILD_TOOLS_URLS = {
++    "linux": "https://dl.google.com/android/repository/build-tools_r34-linux.zip",
++    "darwin": "https://dl.google.com/android/repository/build-tools_r34-macosx.zip",
++}
++_BUILD_TOOLS_SHA256 = {
++    "linux": "e858c4b60069d0431051b225d384413b1643e1289b00a4825aed347f25bd510f",
++    "darwin": "76bf668fe037b1a69197e298ddae5633d4d7f0f41af7ed17e537c80c1ed8a6f3",
++}
++_BUILD_TOOLS_STRIP_PREFIX = "android-14"
++
++_PLATFORM_TOOLS_URLS = {
++    "linux": "https://dl.google.com/android/repository/platform-tools_r37.0.0-linux.zip",
++    "darwin": "https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip",
++}
++_PLATFORM_TOOLS_SHA256 = {
++    "linux": "198ae156ab285fa555987219af237b31102fefe8b9d2bc274708a8d4f2865a07",
++    "darwin": "094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7",
++}
++
++def _hermetic_android_sdk_impl(ctx):
++    if ctx.os.name == "linux":
++        platform = "linux"
++    elif ctx.os.name == "mac os x":
++        platform = "darwin"
++    else:
++        fail("Unsupported host OS for hermetic Android SDK: " + ctx.os.name)
++
++    api_level = ctx.attr.api_level
++    build_tools_version = ctx.attr.build_tools_version
++
++    ctx.download_and_extract(
++        url = _PLATFORM_URL,
++        sha256 = _PLATFORM_SHA256,
++        stripPrefix = _PLATFORM_STRIP_PREFIX,
++        output = "platforms/android-%d" % api_level,
++    )
++    ctx.download_and_extract(
++        url = _BUILD_TOOLS_URLS[platform],
++        sha256 = _BUILD_TOOLS_SHA256[platform],
++        stripPrefix = _BUILD_TOOLS_STRIP_PREFIX,
++        output = "build-tools/%s" % build_tools_version,
++    )
++    ctx.download_and_extract(
++        url = _PLATFORM_TOOLS_URLS[platform],
++        sha256 = _PLATFORM_TOOLS_SHA256[platform],
++        stripPrefix = "platform-tools",
++        output = "platform-tools",
++    )
++
++    ctx.file("emulator/.empty", "")
++    ctx.file("system-images/.empty", "")
++    ctx.file("extras/.empty", "")
++    ctx.file("dummy.jar", "")
++
++    ctx.symlink(ctx.attr._sdk_helper, "helper.bzl")
++    ctx.template("BUILD.bazel", ctx.attr._sdk_template, {
++        "__repository_name__": ctx.name,
++        "__build_tools_version__": build_tools_version,
++        "__build_tools_directory__": build_tools_version,
++        "__api_levels__": str(api_level),
++        "__default_api_level__": str(api_level),
++        "__system_image_dirs__": "",
++    }, executable = False)
++
++_hermetic_android_sdk = repository_rule(
++    implementation = _hermetic_android_sdk_impl,
++    attrs = {
++        "api_level": attr.int(default = _API_LEVEL),
++        "build_tools_version": attr.string(default = _BUILD_TOOLS_VERSION),
++        "_sdk_template": attr.label(default = "@rules_android//rules/android_sdk_repository:template.bzl", allow_single_file = True),
++        "_sdk_helper": attr.label(default = "@rules_android//rules/android_sdk_repository:helper.bzl", allow_single_file = True),
++    },
++)
++
++def _ext_impl(module_ctx):
++    _hermetic_android_sdk(name = "androidsdk")
++
++hermetic_android_sdk_extension = module_extension(
++    implementation = _ext_impl,
++    tag_classes = {},
++)

--- a/registry/modules/rules_kotlin/1.9.0/patches/rules_kotlin_module_bzl_v195.patch
+++ b/registry/modules/rules_kotlin/1.9.0/patches/rules_kotlin_module_bzl_v195.patch
@@ -1,29 +1,23 @@
---- MODULE.bazel	2026-06-23 10:29:47
-+++ MODULE.bazel	2026-06-23 10:47:52
-@@ -10,16 +10,18 @@
- bazel_dep(name = "rules_java", version = "6.4.0")
+--- MODULE.bazel	1999-12-31 16:00:00
++++ MODULE.bazel	2026-06-23 10:48:12
+@@ -10,6 +10,8 @@
+ bazel_dep(name = "rules_java", version = "7.2.0")
  bazel_dep(name = "rules_python", version = "0.23.1")
  bazel_dep(name = "rules_cc", version = "0.0.8")
 +bazel_dep(name = "rules_android", version = "0.6.5")
 +bazel_dep(name = "rules_shell", version = "0.1.2")
  
--rules_kotlin_extensions = use_extension("//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")
-+rules_kotlin_extensions = use_extension(
-+    "//src/main/starlark/core/repositories:bzlmod_setup.bzl",
-+    "rules_kotlin_extensions",
-+)
- use_repo(
-     rules_kotlin_extensions,
--    "buildkite_config",
+ rules_kotlin_extensions = use_extension(
+     "//src/main/starlark/core/repositories:bzlmod_setup.bzl",
+@@ -20,7 +22,6 @@
      "com_github_google_ksp",
      "com_github_jetbrains_kotlin",
      "com_github_pinterest_ktlint",
--    "kt_java_stub_template",
 -    "rules_android",
  )
  
  register_toolchains("//kotlin/internal:default_toolchain")
-@@ -28,6 +30,10 @@
+@@ -29,4 +30,8 @@
  remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
  use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
  
@@ -31,6 +25,4 @@
 +hermetic_android_sdk = use_extension("//:bzl/hermetic_android_sdk.bzl", "hermetic_android_sdk_extension")
 +use_repo(hermetic_android_sdk, "androidsdk")
 +
- # Development dependencies
- # TODO(bencodes) A bunch of these dependencies need to be marked as dev_dependencies but before we can do that
- # we need to sort out a few cases around how these rules are consumed in various ways.
+ bazel_dep(name = "rules_proto", version = "5.3.0-21.7")

--- a/registry/modules/rules_kotlin/1.9.0/source.json
+++ b/registry/modules/rules_kotlin/1.9.0/source.json
@@ -2,7 +2,10 @@
     "integrity": "sha256-V2bx5Zms9VGqVvSdq5q5EIJpsDxVdJbFSsr0H5jiuNY=",
     "url": "https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.0/rules_kotlin-v1.9.0.tar.gz",
     "patches": {
-        "rules_kotlin.patch": "sha256-Q10nhN2KuLJuNM8Y75eHX7Exn0pNXD+oM2wOrYP/nxE="
+        "rules_kotlin.patch": "sha256-Q10nhN2KuLJuNM8Y75eHX7Exn0pNXD+oM2wOrYP/nxE=",
+        "rules_kotlin_hermetic_sdk.patch": "sha256-DODrJycjFBexwGj82tuyDos5p1qnSZ+qu3+pcfbuLOM=",
+        "rules_kotlin_android_sdk.patch": "sha256-lrK5Dr9mODRk6AxWNfMTItB8CwTvgPtxPmERO5dJtlY=",
+        "rules_kotlin_module_bzl.patch": "sha256-7w/yL397RLRlceMjLlWspFAn4by2hXXXau29gjXRxXE="
     },
     "patch_strip": 0
 }


### PR DESCRIPTION
Cherry-pick of the Android bootstrap fix onto the `release/beta-0.1` branch for the `beta-0.1.1` patch release.

Fixes https://github.com/Snapchat/Valdi/issues/106

## Summary
- **Registry**: `rules_kotlin` 1.9.0 `MODULE.bazel` now declares `rules_android` as a dependency and exposes `@androidsdk` via an extension — previously invisible from `rules_kotlin`'s scope, breaking `valdi build android` on clean bootstrap
- **Registry**: New `rules_kotlin_hermetic_sdk.patch` rewrites `third_party:android_sdk` to use hermetic `@androidsdk` jar
- **Registry**: Rewritten `rules_kotlin_module_bzl.patch` targeting v1.9.0 source content + new `rules_kotlin_module_bzl_v195.patch` for build compatibility
- **CLI template**: `MODULE.bazel.template` adds full Android dependency section (rules_android, rules_kotlin, hermetic SDK/NDK, maven, toolchains)
- **CLI template**: `.bazelrc.template` bumps `tool_java_language_version` 11→17 (rules_android@0.6.5 uses Java records requiring Java 16+)
- **Tests**: Android build smoke test unskipped

## Background
Bazel uses the registry `MODULE.bazel` (not source patches) for module resolution. The Valdi registry's `rules_kotlin` 1.9.0 `MODULE.bazel` didn't declare `rules_android` as a dependency, so `@androidsdk` was invisible from `rules_kotlin`'s scope, causing `valdi install android` / `valdi build android` to fail on any project bootstrapped with `beta-0.1.0`.

## Cherry-picked from
Main branch commit `f6b38118614f`

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tests pass locally (`bazel test //...`)
- [x] Tested on multiple platforms (iOS/Android/Web/macOS as applicable)
- [x] Manual testing performed (describe below)

### Testing Details
- Local verification: `--localValdiPath` bootstrap → `valdi build android` → APK builds (23k actions)

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes (or documented in description)
- [x] No secrets, API keys, or internal URLs included

## Release Plan
1. ~~Land fix on main~~ ✅
2. ~~Create `release/beta-0.1` branch from `beta-0.1.0` tag~~ ✅
3. ~~Cherry-pick fix onto release branch~~ ✅ (this PR)
4. Tag `beta-0.1.1` from release branch tip
5. Create GitHub pre-release → triggers release test workflow
6. Manual verification with fresh bootstrap
7. Tag `Valdi_Widgets` `beta-0.1.1`
8. Bump CLI defaults (`DEFAULT_VALDI_RELEASE_TAG` → `beta-0.1.1`, CLI version → `1.1.6`)