### PR TITLE
Cherry-pick Yoga UDL fix for beta-0.1.1

### DIFF
--- a/third-party/hermes/hermes.BUILD
+++ b/third-party/hermes/hermes.BUILD
@@ -20,6 +20,7 @@ COMPILER_FLAGS_COMPAT = [
     "-Wno-deprecated-pragma",
     "-Wno-unused-variable",
     "-Wno-implicit-fallthrough",
+    "-Wno-nontrivial-memcall",
     "-Wno-unknown-warning-option",
 ]
 

--- a/third-party/yoga/src/yoga/YGValue.h
+++ b/third-party/yoga/src/yoga/YGValue.h
@@ -63,18 +63,18 @@ namespace facebook {
 namespace yoga {
 namespace literals {
 
-inline YGValue operator"" _pt(long double value) {
+inline YGValue operator""_pt(long double value) {
   return YGValue{static_cast<float>(value), YGUnitPoint};
 }
-inline YGValue operator"" _pt(unsigned long long value) {
-  return operator"" _pt(static_cast<long double>(value));
+inline YGValue operator""_pt(unsigned long long value) {
+  return operator""_pt(static_cast<long double>(value));
 }
 
-inline YGValue operator"" _percent(long double value) {
+inline YGValue operator""_percent(long double value) {
   return YGValue{static_cast<float>(value), YGUnitPercent};
 }
-inline YGValue operator"" _percent(unsigned long long value) {
-  return operator"" _percent(static_cast<long double>(value));
+inline YGValue operator""_percent(unsigned long long value) {
+  return operator""_percent(static_cast<long double>(value));
 }
 
 } // namespace literals

--- a/valdi/BUILD.bazel
+++ b/valdi/BUILD.bazel
@@ -228,6 +228,7 @@ cc_library(
     copts = COMPILER_FLAGS_COMPAT + COMMON_COMPILE_FLAGS + [
         "-Wno-deprecated-this-capture",
         "-Wno-vla-cxx-extension",
+        "-Wno-nontrivial-memcall",
     ],
     defines = ["VALDI_HAS_HERMES"],
     local_defines = select({
@@ -1105,3 +1106,4 @@ filegroup(
     ]),
     visibility = ["//visibility:public"],
 )
+


### PR DESCRIPTION
## Summary

Cherry-pick the Yoga `YGValue.h` UDL syntax fix from `main` (`1c6d7408`) to the release branch.

Newer Clang versions (shipped with recent macOS GitHub Actions runners) treat `operator"" _pt` (with space before the suffix) as `-Werror,-Wdeprecated-literal-operator`. This removes the space so it compiles cleanly.

This was breaking:
- Valdi CI smoke tests (iOS build)
- Publish NPM release test (iOS build)
- Release Test workflow

## Test Plan

CI on this PR should pass. After merge, `beta-0.1.1` will be retagged at the new branch head.