### PR TITLE
Pre-size valdi_core bridge dictionaries and maps

### DIFF
--- a/valdi_core/src/valdi_core/ios/valdi_core/SCValdiObjCConversionUtils.mm
+++ b/valdi_core/src/valdi_core/ios/valdi_core/SCValdiObjCConversionUtils.mm
@@ -349,6 +349,7 @@ id<SCValdiFunction> FunctionFromValueFunction(const Valdi::Ref<Valdi::ValueFunct
 
     Valdi::Value ValueFromNSDictionary(NSDictionary<NSString *, id> *dict) {
         auto map = Valdi::makeShared<Valdi::ValueMap>();
+        map->reserve(dict.count);
         for (NSString *key in dict) {
             id value = [dict objectForKey:key];
             auto weakValue = ValueFromNSObject(value);

--- a/valdi_core/src/valdi_core/ios/valdi_core/SCValdiObjCConversionUtils.mm
+++ b/valdi_core/src/valdi_core/ios/valdi_core/SCValdiObjCConversionUtils.mm
@@ -219,8 +219,9 @@ public:
                 return @(value.toBool());
             case Valdi::ValueType::Map:
             {
-                NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-                for (const auto &it : *value.getMap()) {
+                const auto &valueMap = *value.getMap();
+                NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithCapacity:valueMap.size()];
+                for (const auto &it : valueMap) {
                     dictionary[NSStringFromString(it.first)] = NSObjectFromValue(it.second);
                 }
 
@@ -244,7 +245,7 @@ public:
             case Valdi::ValueType::TypedObject:
             {
                 const auto &typedObject = *value.getTypedObject();
-                NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+                NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithCapacity:typedObject.getPropertiesSize()];
                 for (const auto &property: typedObject) {
                     dictionary[NSStringFromString(property.name)] = NSObjectFromValue(property.value);
                 }


### PR DESCRIPTION
# [iOS] Pre-size valdi_core bridge dictionaries and maps

## Description

We ran into a workload that pushes a large number of small dictionaries (4-8 keys each) through the validi bridge. The bridge builds its dictionaries/maps with no capacity hint, so each one starts at the minimum size and grows as it fills — at 4-8 keys that's multiple resize boundaries crossed *per item*, each one a rehash/realloc plus a free of the smaller backing buffer. Multiply by the number of items and we're churning a lotttt of transient memory for dictionaries whose final size we already know up front.

The array bridging cases elsewhere in this file already do pre-allocation, so it makes sense to mirror that, I think.

* JS -> ObjC (`NSObjectFromValue`): build the `Map` and `TypedObject` `NSMutableDictionary` with `dictionaryWithCapacity:` (map size / property count), matching the `Array` case right below it.
* ObjC -> JS (`ValueFromNSDictionary`): `reserve(dict.count)` on the `ValueMap` before the insert loop, matching the typed and array paths.

There's also obviously some bigger optimization options but this one stood out as a good "starter bug" candidate.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation improvement
- [x] Performance optimization
- [ ] Test improvement
- [ ] Other (please describe)

## Testing
- [x] Tests pass locally (`bazel test //...`)
- [ ] Added/updated tests for changes (if applicable)
- [ ] Tested on multiple platforms (iOS/Android/Web/macOS as applicable)
- [ ] Manual testing performed (describe below)

### Testing Details

Covered by the existing test suite (`valdi/test/ios/SCValdiMarshallerTests.m`) — `testCanMarshallMap` / `testCanUnmarshallMap` round-trip an untyped `NSDictionary` through both changed functions (`ValueFromNSDictionary` and `NSObjectFromValue`'s map case). No new tests since only the initial capacity changes, not the contents or ordering.

Ran `bazel test //...` locally: 63/72 targets pass, including everything this change compiles into (`//valdi:valdi_ios_objc_test`, `valdi_ios_swift_test`, `valdi_macos_objc_test`). The 7 that fail (e.g. `//valdi:test_java`, `//libs/dummy:test`) fail identically on a clean `main` checkout, so that's pre-existing local breakage rather than anything from this change.

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented in description)
- [x] Commit messages follow [conventional format](../CONTRIBUTING.md#commit-messages)
- [x] No secrets, API keys, or internal URLs included

## Related Issues

## Additional Context
