### PR TITLE
Test: Slack notification wiring (ignore — closing immediately)

### DIFF
--- a/SLACK_NOTIFICATION_TEST.md
+++ b/SLACK_NOTIFICATION_TEST.md
@@ -1,0 +1,2 @@
+Temporary file to verify the GitHub Slack app notification wiring for #valdi-support.
+This PR will be closed without merging.


### PR DESCRIPTION
Verifying that the GitHub Slack app posts new PRs to the internal #valdi-support channel.

No-op change, not intended to merge. Closing as soon as the notification lands.