### PR TITLE
Test: Eeny reviewer-pick workflow (ignore — closing shortly)

### DIFF
--- a/SLACK_NOTIFICATION_TEST.md
+++ b/SLACK_NOTIFICATION_TEST.md
@@ -1,0 +1,2 @@
+Temporary file to verify the Eeny reviewer-pick workflow fires on GitHub Slack app notifications.
+This PR will be closed without merging.


### PR DESCRIPTION
Second wiring test: confirming the Valdi PR Review Slack workflow matches the GitHub app notification and triggers an Eeny reviewer pick.

No-op change, not intended to merge. Leaving open just long enough to observe the Slack thread.