### PR TITLE
Fix inspect command packaging

### DIFF
--- a/npm_modules/cli/package.json
+++ b/npm_modules/cli/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "prepare": "npm run build",
-    "prebuild": "node scripts/bundle-skills.js",
+    "prebuild": "node scripts/clean-dist.js && node scripts/bundle-skills.js",
     "build": "npm exec --package=typescript@5.9.2 tsc -- --project ./tsconfig.dist.json",
     "test": "tsx node_modules/jasmine/bin/jasmine",
     "watch": "tsc --watch",

--- a/npm_modules/cli/scripts/clean-dist.js
+++ b/npm_modules/cli/scripts/clean-dist.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+
+fs.rmSync(path.join(__dirname, '..', 'dist'), {
+  recursive: true,
+  force: true,
+});

--- a/npm_modules/cli/test/commands/inspect_commands/snapshot.spec.ts
+++ b/npm_modules/cli/test/commands/inspect_commands/snapshot.spec.ts
@@ -1,5 +1,5 @@
 import 'jasmine';
-import { firstElementId, findElementByKey } from './snapshot';
+import { findElementByKey, firstElementId } from '../../../src/commands/inspect_commands/snapshot';
 
 describe('snapshot tree helpers', () => {
   describe('firstElementId', () => {


### PR DESCRIPTION
## Summary

- move the snapshot helper spec out of the runtime command source tree
- clean the CLI dist directory before compilation to prevent stale command files
- prevent published CLI builds from loading Jasmine specs as inspect commands

## Verification

- npm test: 91 specs, 0 failures
- npm run build
- verified dist/commands contains no spec or test JavaScript files
- ran the rebuilt CLI against a live Android app: inspect status connected and inspect devices found com.snap.valdi.ayab_valdi_app