### PR TITLE
Remove stale git-LFS compiler pointer files from bin/compiler

### DIFF
--- a/bin/compiler/linux/valdi_compiler
+++ b/bin/compiler/linux/valdi_compiler
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:693f133e6470ea35e69999045f44480bf41e4d1dddcc4dd92c7432fd17c8fd2a
-size 64559200

--- a/bin/compiler/macos/valdi_compiler
+++ b/bin/compiler/macos/valdi_compiler
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1c26b4569e03879c548340567b572bba48f92b9a38017d69f04a7cfc2eaec7b
-size 49032560


### PR DESCRIPTION
## What

Removes two orphaned git-LFS pointer files:

- `bin/compiler/macos/valdi_compiler`
- `bin/compiler/linux/valdi_compiler`

## Why

These are stale git-LFS **pointer files** left over from before the LFS→GCS-archive migration. They are 133-byte stubs referencing large LFS objects (~49 MB / ~64 MB), and:

- The public repo no longer has an LFS filter for `bin/**` in `.gitattributes`, so these are **orphaned pointers**.
- The public build compiles the compiler **from source** (`use_local_compiler=True` in the export transform), so these binaries are **not used**.
- Copybara cannot remove them: `bin/compiler/**` is in `REPO_EXCLUDES`, which feeds the workflow's `destination_files`, so copybara treats those paths as out-of-scope and never deletes them.

## Note

This removes the pointer files from `main`. The underlying LFS objects remain in LFS storage/history until separately garbage-collected (needs a history operation / GitHub support) — out of scope for this PR.