### PR TITLE
fix: Validate project name as a Bazel module name during bootstrap

### DIFF
--- a/npm_modules/cli/src/commands/bootstrap.ts
+++ b/npm_modules/cli/src/commands/bootstrap.ts
@@ -112,7 +112,7 @@ async function getProjectName(argv: ArgumentsResolver<CommandParameters>): Promi
       ]);
 
       projectName = result.projectName;
-      const validationError = validateProjectName(projectName);
+      const validationError = validateProjectName(projectName, { bazelModule: true });
 
       if (validationError) {
         console.log(wrapInColor(`\n❌ ${validationError}\n`, ANSI_COLORS.RED_COLOR));
@@ -306,7 +306,7 @@ async function valdiBootstrap(argv: ArgumentsResolver<CommandParameters>) {
   
   // Validate project name if provided via command line argument
   if (argv.getArgument('projectName')) {
-    const validationError = validateProjectName(projectName);
+    const validationError = validateProjectName(projectName, { bazelModule: true });
     if (validationError) {
       throw new CliError(validationError);
     }

--- a/npm_modules/cli/src/commands/bootstrap.ts
+++ b/npm_modules/cli/src/commands/bootstrap.ts
@@ -112,7 +112,7 @@ async function getProjectName(argv: ArgumentsResolver<CommandParameters>): Promi
       ]);
 
       projectName = result.projectName;
-      const validationError = validateProjectName(projectName, { bazelModule: true });
+      const validationError = validateProjectName(projectName, { requireBazelModuleName: true });
 
       if (validationError) {
         console.log(wrapInColor(`\n❌ ${validationError}\n`, ANSI_COLORS.RED_COLOR));
@@ -306,7 +306,7 @@ async function valdiBootstrap(argv: ArgumentsResolver<CommandParameters>) {
   
   // Validate project name if provided via command line argument
   if (argv.getArgument('projectName')) {
-    const validationError = validateProjectName(projectName, { bazelModule: true });
+    const validationError = validateProjectName(projectName, { requireBazelModuleName: true });
     if (validationError) {
       throw new CliError(validationError);
     }

--- a/npm_modules/cli/src/utils/stringUtils.spec.ts
+++ b/npm_modules/cli/src/utils/stringUtils.spec.ts
@@ -110,8 +110,8 @@ describe('stringUtils', () => {
         expect(validateProjectName('123project')).toContain('sanitized');
       });
 
-      describe('with bazelModule option', () => {
-        const opts = { bazelModule: true };
+      describe('with requireBazelModuleName option', () => {
+        const opts = { requireBazelModuleName: true };
 
         it('accepts valid Bazel module names', () => {
           expect(validateProjectName('my_project', opts)).toBeNull();

--- a/npm_modules/cli/src/utils/stringUtils.spec.ts
+++ b/npm_modules/cli/src/utils/stringUtils.spec.ts
@@ -84,11 +84,13 @@ describe('stringUtils', () => {
         expect(validateProjectName('package')).toContain('reserved word');
       });
 
-      it('accepts valid names', () => {
+      it('accepts valid names with mixed case', () => {
         expect(validateProjectName('my_project')).toBeNull();
         expect(validateProjectName('myproject')).toBeNull();
         expect(validateProjectName('my_cool_app')).toBeNull();
         expect(validateProjectName('project123')).toBeNull();
+        expect(validateProjectName('MyProject')).toBeNull();
+        expect(validateProjectName('testNewModule')).toBeNull();
       });
 
       it('accepts names with dashes (they will be sanitized)', () => {
@@ -102,23 +104,40 @@ describe('stringUtils', () => {
         expect(validateProjectName('@#$')).toBeTruthy();
       });
 
-      it('rejects names that are not valid Bazel module names', () => {
-        // Regression: these used to pass validation and only fail once Bazel read the
-        // generated MODULE.bazel, i.e. after the project files had been written.
-        expect(validateProjectName('MyProject')).toContain('not a valid Bazel module name');
-        expect(validateProjectName('testNewModule')).toContain('not a valid Bazel module name');
-        expect(validateProjectName('MY_PROJECT')).toContain('not a valid Bazel module name');
-        expect(validateProjectName('_')).toContain('not a valid Bazel module name');
+      it('handles names that start with numbers', () => {
+        // Names starting with numbers get prefixed with underscore during sanitization,
+        // so validateProjectName returns a warning about the change
+        expect(validateProjectName('123project')).toContain('sanitized');
       });
 
-      it('suggests a valid name when one can be derived', () => {
-        expect(validateProjectName('MyProject')).toContain('Did you mean "myproject"?');
-        expect(validateProjectName('My-Project')).toContain('Did you mean "my_project"?');
-      });
+      describe('with bazelModule option', () => {
+        const opts = { bazelModule: true };
 
-      it('rejects names that start with numbers', () => {
-        // Bazel module names must begin with a lowercase letter
-        expect(validateProjectName('123project')).toContain('not a valid Bazel module name');
+        it('accepts valid Bazel module names', () => {
+          expect(validateProjectName('my_project', opts)).toBeNull();
+          expect(validateProjectName('myproject', opts)).toBeNull();
+          expect(validateProjectName('my-project', opts)).toBeNull();
+          expect(validateProjectName('project123', opts)).toBeNull();
+        });
+
+        it('rejects names that are not valid Bazel module names', () => {
+          // Regression: these used to pass validation and only fail once Bazel read the
+          // generated MODULE.bazel, i.e. after the project files had been written.
+          expect(validateProjectName('MyProject', opts)).toContain('not a valid Bazel module name');
+          expect(validateProjectName('testNewModule', opts)).toContain('not a valid Bazel module name');
+          expect(validateProjectName('MY_PROJECT', opts)).toContain('not a valid Bazel module name');
+          expect(validateProjectName('_', opts)).toContain('not a valid Bazel module name');
+        });
+
+        it('suggests a valid name when one can be derived', () => {
+          expect(validateProjectName('MyProject', opts)).toContain('Did you mean "myproject"?');
+          expect(validateProjectName('My-Project', opts)).toContain('Did you mean "my_project"?');
+        });
+
+        it('rejects names that start with numbers', () => {
+          // Bazel module names must begin with a lowercase letter
+          expect(validateProjectName('123project', opts)).toContain('not a valid Bazel module name');
+        });
       });
     });
 });

--- a/npm_modules/cli/src/utils/stringUtils.spec.ts
+++ b/npm_modules/cli/src/utils/stringUtils.spec.ts
@@ -1,5 +1,5 @@
 import 'jasmine';
-import { sanitizeProjectName, toPascalCase, toSnakeCase, validateProjectName } from './stringUtils';
+import { isValidBazelModuleName, sanitizeProjectName, toPascalCase, toSnakeCase, validateProjectName } from './stringUtils';
 
 describe('stringUtils', () => {
     it('converts strings to pascal case', () => {
@@ -50,6 +50,24 @@ describe('stringUtils', () => {
       });
     });
 
+    describe('isValidBazelModuleName', () => {
+      it('accepts names Bazel accepts', () => {
+        expect(isValidBazelModuleName('myproject')).toBe(true);
+        expect(isValidBazelModuleName('my_project')).toBe(true);
+        expect(isValidBazelModuleName('my.cool-project123')).toBe(true);
+        expect(isValidBazelModuleName('a')).toBe(true);
+      });
+
+      it('rejects names Bazel rejects', () => {
+        expect(isValidBazelModuleName('MyProject')).toBe(false);
+        expect(isValidBazelModuleName('MY_PROJECT')).toBe(false);
+        expect(isValidBazelModuleName('_my_project')).toBe(false);
+        expect(isValidBazelModuleName('123project')).toBe(false);
+        expect(isValidBazelModuleName('my_project_')).toBe(false);
+        expect(isValidBazelModuleName('')).toBe(false);
+      });
+    });
+
     describe('validateProjectName', () => {
       it('rejects empty names', () => {
         expect(validateProjectName('')).toBeTruthy();
@@ -66,13 +84,11 @@ describe('stringUtils', () => {
         expect(validateProjectName('package')).toContain('reserved word');
       });
 
-      it('accepts valid names with mixed case', () => {
+      it('accepts valid names', () => {
         expect(validateProjectName('my_project')).toBeNull();
         expect(validateProjectName('myproject')).toBeNull();
         expect(validateProjectName('my_cool_app')).toBeNull();
         expect(validateProjectName('project123')).toBeNull();
-        expect(validateProjectName('MyProject')).toBeNull();
-        expect(validateProjectName('testNewModule')).toBeNull();
       });
 
       it('accepts names with dashes (they will be sanitized)', () => {
@@ -86,10 +102,23 @@ describe('stringUtils', () => {
         expect(validateProjectName('@#$')).toBeTruthy();
       });
 
-      it('handles names that start with numbers', () => {
-        // Names starting with numbers get prefixed with underscore during sanitization,
-        // so validateProjectName returns a warning about the change
-        expect(validateProjectName('123project')).toContain('sanitized');
+      it('rejects names that are not valid Bazel module names', () => {
+        // Regression: these used to pass validation and only fail once Bazel read the
+        // generated MODULE.bazel, i.e. after the project files had been written.
+        expect(validateProjectName('MyProject')).toContain('not a valid Bazel module name');
+        expect(validateProjectName('testNewModule')).toContain('not a valid Bazel module name');
+        expect(validateProjectName('MY_PROJECT')).toContain('not a valid Bazel module name');
+        expect(validateProjectName('_')).toContain('not a valid Bazel module name');
+      });
+
+      it('suggests a valid name when one can be derived', () => {
+        expect(validateProjectName('MyProject')).toContain('Did you mean "myproject"?');
+        expect(validateProjectName('My-Project')).toContain('Did you mean "my_project"?');
+      });
+
+      it('rejects names that start with numbers', () => {
+        // Bazel module names must begin with a lowercase letter
+        expect(validateProjectName('123project')).toContain('not a valid Bazel module name');
       });
     });
 });

--- a/npm_modules/cli/src/utils/stringUtils.ts
+++ b/npm_modules/cli/src/utils/stringUtils.ts
@@ -80,7 +80,7 @@ export interface ValidateProjectNameOptions {
    * `valdi bootstrap`). Module and target names created by `valdi new_module`
    * are case-sensitive directory/BUILD target names and do not need this.
    */
-  bazelModule?: boolean;
+  requireBazelModuleName?: boolean;
 }
 
 /**
@@ -104,7 +104,7 @@ export function validateProjectName(name: string, options: ValidateProjectNameOp
 
   // When the name is used as the Bazel module name in MODULE.bazel, reject anything
   // Bazel would refuse before any files are written.
-  if (options.bazelModule && !isValidBazelModuleName(sanitized)) {
+  if (options.requireBazelModuleName && !isValidBazelModuleName(sanitized)) {
     const suggestion = sanitized.toLowerCase().replace(/^[^a-z]+/, '').replace(/[^\da-z]+$/, '');
     return (
       `Project name "${name}" is not a valid Bazel module name. ` +

--- a/npm_modules/cli/src/utils/stringUtils.ts
+++ b/npm_modules/cli/src/utils/stringUtils.ts
@@ -62,6 +62,18 @@ export function sanitizeProjectName(name: string): string {
 }
 
 /**
+ * The project name is used as the Bazel module name in `module(name = ...)` in
+ * MODULE.bazel, which Bazel requires to 1) only contain lowercase letters (a-z),
+ * digits (0-9), dots (.), hyphens (-) and underscores (_), 2) begin with a
+ * lowercase letter and 3) end with a lowercase letter or digit.
+ */
+const BAZEL_MODULE_NAME_REGEX = /^[a-z]([\d._a-z-]*[\da-z])?$/;
+
+export function isValidBazelModuleName(name: string): boolean {
+  return BAZEL_MODULE_NAME_REGEX.test(name);
+}
+
+/**
  * Validates a project name and returns an error message if invalid, or null if valid.
  */
 export function validateProjectName(name: string): string | null {
@@ -79,7 +91,19 @@ export function validateProjectName(name: string): string | null {
   if (RESERVED_PROJECT_NAMES.has(sanitized.toLowerCase())) {
     return `Project name "${name}" (sanitized to "${sanitized}") is a reserved word and cannot be used. Please choose a different name.`;
   }
-  
+
+  // The name is used as the Bazel module name in MODULE.bazel, so reject anything
+  // Bazel would refuse before any files are written.
+  if (!isValidBazelModuleName(sanitized)) {
+    const suggestion = sanitized.toLowerCase().replace(/^[^a-z]+/, '').replace(/[^\da-z]+$/, '');
+    return (
+      `Project name "${name}" is not a valid Bazel module name. ` +
+      `It must only contain lowercase letters (a-z), digits (0-9), dots (.), hyphens (-) and underscores (_), ` +
+      `begin with a lowercase letter and end with a lowercase letter or digit.` +
+      (suggestion ? ` Did you mean "${suggestion}"?` : '')
+    );
+  }
+
   // Warn if the name was significantly changed during sanitization
   if (sanitized !== name.replace(/-/g, '_')) {
     return `Project name "${name}" contains invalid characters. It will be sanitized to "${sanitized}". Please use only letters, numbers, underscores, and dashes.`;

--- a/npm_modules/cli/src/utils/stringUtils.ts
+++ b/npm_modules/cli/src/utils/stringUtils.ts
@@ -73,10 +73,20 @@ export function isValidBazelModuleName(name: string): boolean {
   return BAZEL_MODULE_NAME_REGEX.test(name);
 }
 
+export interface ValidateProjectNameOptions {
+  /**
+   * Also require the sanitized name to be a valid Bazel module name. Only needed
+   * when the name becomes the `module(name = ...)` of a new MODULE.bazel (i.e.
+   * `valdi bootstrap`). Module and target names created by `valdi new_module`
+   * are case-sensitive directory/BUILD target names and do not need this.
+   */
+  bazelModule?: boolean;
+}
+
 /**
  * Validates a project name and returns an error message if invalid, or null if valid.
  */
-export function validateProjectName(name: string): string | null {
+export function validateProjectName(name: string, options: ValidateProjectNameOptions = {}): string | null {
   if (!name || name.trim().length === 0) {
     return 'Project name cannot be empty.';
   }
@@ -92,9 +102,9 @@ export function validateProjectName(name: string): string | null {
     return `Project name "${name}" (sanitized to "${sanitized}") is a reserved word and cannot be used. Please choose a different name.`;
   }
 
-  // The name is used as the Bazel module name in MODULE.bazel, so reject anything
+  // When the name is used as the Bazel module name in MODULE.bazel, reject anything
   // Bazel would refuse before any files are written.
-  if (!isValidBazelModuleName(sanitized)) {
+  if (options.bazelModule && !isValidBazelModuleName(sanitized)) {
     const suggestion = sanitized.toLowerCase().replace(/^[^a-z]+/, '').replace(/[^\da-z]+$/, '');
     return (
       `Project name "${name}" is not a valid Bazel module name. ` +


### PR DESCRIPTION
## Problem

`valdi bootstrap` accepts a project name like `MyProject`, then fails at the very end, after the project files are already written:

```
Error in module: invalid module name 'MyProject': valid names must
1) only contain lowercase letters (a-z), digits (0-9), dots (.), hyphens (-),
and underscores (_); 2) begin with a lowercase letter; ...
```

The name becomes `module(name = ...)` in `MODULE.bazel`, which Bazel requires to be lowercase. Nothing checks that until Bazel runs. Re-running bootstrap then fails with `Detected existing project files`, so you have to clean up by hand first (or the cleanup version)

## Fix

Check the name against Bazel's rules at the prompt, before any files are created:

```
❌ Project name "MyProject" is not a valid Bazel module name. It must only contain
lowercase letters (a-z), digits (0-9), dots (.), hyphens (-) and underscores (_),
begin with a lowercase letter and end with a lowercase letter or digit.
Did you mean "myproject"?
```

The name is not corrected automatically — directory and target names stay case-sensitive, so that stays the user's choice.

Note: `123project` is now rejected instead of being turned into `_123project`.