### PR TITLE
fix: Hand the Android back button back to the platform

### DIFF
--- a/valdi/src/android_support/java/com/snap/valdi/support/AppBootstrapActivity.kt
+++ b/valdi/src/android_support/java/com/snap/valdi/support/AppBootstrapActivity.kt
@@ -92,12 +92,17 @@ abstract class AppBootstrapActivity: AppCompatActivity() {
 
     override fun onBackPressed() {
         val listener = this.valdiRootView?.onBackButtonListener
-        if (listener != null) {
-            listener.onBackButtonPressed()
-        } else {
-            navigationView?.pop(true) {
-                (it as? Disposable)?.dispose()
-            }
+        if (listener != null && listener.onBackButtonPressed()) {
+            return
+        }
+
+        val popped = navigationView?.pop(true) {
+            (it as? Disposable)?.dispose()
+        } ?: false
+
+        if (!popped) {
+            // Nothing handled the back press, let the platform close the activity
+            super.onBackPressed()
         }
     }
 }


### PR DESCRIPTION
## Problem

On Android, the back button does nothing in a bootstrapped app — you can't get out of it.

`AppBootstrapActivity.onBackPressed()` calls a handler but ignores whether it handled the press, and never falls back to `super.onBackPressed()`. With no back handler registered and a single screen on the stack — a freshly bootstrapped app — the press is swallowed.

## Fix

Try each handler in turn, and give the press back to the platform if none took it:

1. the component's back handler (returns whether it handled the press)
2. the navigation stack pop (returns `false` when there's nothing to pop)
3. `super.onBackPressed()`

Note: a back handler returning `false` now falls through to the navigation stack, where before it stopped there.

Verified on a bootstrapped app built against `beta-0.1.1` with this patch applied: back exits to the launcher, and still pops correctly with more than one screen.