### PR TITLE
Fix: generated type headers self-import, breaking clang module / Swift interop builds

### DIFF
--- a/compiler/compiler/Compiler/Sources/Processors/CombineNativeSourcesProcessor.swift
+++ b/compiler/compiler/Compiler/Sources/Processors/CombineNativeSourcesProcessor.swift
@@ -56,16 +56,40 @@ final class CombineNativeSourcesProcessor: CompilationProcessor {
         return allItems
     }
 
-    private func mergeAnySources(files: [FileAndContent]) -> File {
+    private func mergeAnySources(files: [FileAndContent], outputFilename: String) -> File {
         var data = ""
 
         for file in files {
             data +=  "//\n// \(file.filename)\n//\n\n"
-            data += file.content
+            data += Self.filterSelfImports(from: file.content, outputFilename: outputFilename)
             data += "\n"
         }
 
         return .string(data)
+    }
+
+    /// Each generated ObjC source header imports the module's own consolidated
+    /// header by its canonical name (see `IOSType.importHeaderStatement`). After
+    /// merging into that very file the import refers to itself. It is a no-op
+    /// under normal (hmap-based) compilation, but it breaks clang module builds
+    /// for Swift interop (Swift module compilation receives no header maps), so
+    /// drop those import lines here.
+    static func filterSelfImports(from content: String, outputFilename: String) -> String {
+        let stem = (outputFilename as NSString).deletingPathExtension
+        let selfImports: Set<String> = [
+            "#import <\(outputFilename)>",
+            "#import \"\(outputFilename)\"",
+            "#import <\(stem)/\(outputFilename)>",
+        ]
+        var data = ""
+
+        for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
+            if selfImports.contains(line.trimmingCharacters(in: .whitespaces)) { continue }
+            data += line
+            data += "\n"
+        }
+
+        return data
     }
 
     // Merges .m files and deduplicates static trampoline functions
@@ -362,7 +386,7 @@ final class CombineNativeSourcesProcessor: CompilationProcessor {
             let file = mergeObjcSources(files: fileAndContentArray)
             generatedNativeSource = NativeSource(relativePath: relativePath, filename: filename, file: file, groupingIdentifier: filename, groupingPriority: 0)
         } else {
-            let file = mergeAnySources(files: fileAndContentArray)
+            let file = mergeAnySources(files: fileAndContentArray, outputFilename: filename)
             generatedNativeSource = NativeSource(relativePath: relativePath, filename: filename, file: file, groupingIdentifier: filename, groupingPriority: 0)
         }
 

--- a/compiler/compiler/Compiler/Sources/Processors/CombineNativeSourcesProcessor.swift
+++ b/compiler/compiler/Compiler/Sources/Processors/CombineNativeSourcesProcessor.swift
@@ -81,15 +81,10 @@ final class CombineNativeSourcesProcessor: CompilationProcessor {
             "#import \"\(outputFilename)\"",
             "#import <\(stem)/\(outputFilename)>",
         ]
-        var data = ""
-
-        for line in content.split(separator: "\n", omittingEmptySubsequences: false) {
-            if selfImports.contains(line.trimmingCharacters(in: .whitespaces)) { continue }
-            data += line
-            data += "\n"
-        }
-
-        return data
+        return content
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !selfImports.contains($0.trimmingCharacters(in: .whitespaces)) }
+            .joined(separator: "\n")
     }
 
     // Merges .m files and deduplicates static trampoline functions

--- a/compiler/compiler/Compiler/Tests/CompilerTests/CombineNativeSourcesProcessorTests.swift
+++ b/compiler/compiler/Compiler/Tests/CompilerTests/CombineNativeSourcesProcessorTests.swift
@@ -49,7 +49,7 @@ final class CombineNativeSourcesProcessorTests: XCTestCase {
 
         let filtered = CombineNativeSourcesProcessor.filterSelfImports(from: content, outputFilename: "TestTypes.h")
 
-        XCTAssertEqual("@interface Foo : NSObject\n@end\n\n", filtered)
+        XCTAssertEqual("@interface Foo : NSObject\n@end\n", filtered)
     }
 
     func testFilterSelfImportsPreservesContentWithoutSelfImports() {
@@ -57,6 +57,6 @@ final class CombineNativeSourcesProcessorTests: XCTestCase {
 
         let filtered = CombineNativeSourcesProcessor.filterSelfImports(from: content, outputFilename: "TestTypes.h")
 
-        XCTAssertEqual("#import <Foundation/Foundation.h>\n\n@interface Foo : NSObject\n@end\n\n", filtered)
+        XCTAssertEqual("#import <Foundation/Foundation.h>\n\n@interface Foo : NSObject\n@end\n", filtered)
     }
 }

--- a/compiler/compiler/Compiler/Tests/CompilerTests/CombineNativeSourcesProcessorTests.swift
+++ b/compiler/compiler/Compiler/Tests/CompilerTests/CombineNativeSourcesProcessorTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Compiler
+
+final class CombineNativeSourcesProcessorTests: XCTestCase {
+
+    // Under single_file_codegen, merged headers previously contained imports of
+    // themselves (eg. `#import <TestTypes/TestTypes.h>` inside TestTypes.h).
+    // Those are no-ops under header maps but break clang module builds used
+    // for Swift interop, so they must be dropped while merging.
+    func testFilterSelfImportsDropsAllSelfImportForms() {
+        let content = [
+            "#import <Foundation/Foundation.h>",
+            "#import <TestTypes/TestTypes.h>",  // canonical module-prefixed form
+            "#import <TestTypes.h>",            // bare angled form
+            "#import \"TestTypes.h\"",          // quoted form
+            "@interface TestTypes : NSObject",
+            "@end",
+        ].joined(separator: "\n")
+
+        let filtered = CombineNativeSourcesProcessor.filterSelfImports(from: content, outputFilename: "TestTypes.h")
+
+        XCTAssertFalse(filtered.contains("#import <TestTypes/TestTypes.h>"))
+        XCTAssertFalse(filtered.contains("#import <TestTypes.h>"))
+        XCTAssertFalse(filtered.contains("#import \"TestTypes.h\""))
+        XCTAssertTrue(filtered.contains("#import <Foundation/Foundation.h>"))
+        XCTAssertTrue(filtered.contains("@interface TestTypes : NSObject"))
+    }
+
+    func testFilterSelfImportsKeepsImportsOfOtherHeaders() {
+        // The module's main header must survive inside the Types header, and
+        // vice versa; only imports of the merged output file itself are dropped.
+        let content = [
+            "#import <Test/Test.h>",
+            "#import \"Test.h\"",
+            "#import <valdi_core/SCVTypes.h>",
+            "#import <TestTypes/TestTypes.h>",
+        ].joined(separator: "\n")
+
+        let filtered = CombineNativeSourcesProcessor.filterSelfImports(from: content, outputFilename: "TestTypes.h")
+
+        XCTAssertTrue(filtered.contains("#import <Test/Test.h>"))
+        XCTAssertTrue(filtered.contains("#import \"Test.h\""))
+        XCTAssertTrue(filtered.contains("#import <valdi_core/SCVTypes.h>"))
+        XCTAssertFalse(filtered.contains("#import <TestTypes/TestTypes.h>"))
+    }
+
+    func testFilterSelfImportsMatchesIndentedLines() {
+        let content = "  #import <TestTypes/TestTypes.h>\n@interface Foo : NSObject\n@end\n"
+
+        let filtered = CombineNativeSourcesProcessor.filterSelfImports(from: content, outputFilename: "TestTypes.h")
+
+        XCTAssertEqual("@interface Foo : NSObject\n@end\n\n", filtered)
+    }
+
+    func testFilterSelfImportsPreservesContentWithoutSelfImports() {
+        let content = "#import <Foundation/Foundation.h>\n\n@interface Foo : NSObject\n@end\n"
+
+        let filtered = CombineNativeSourcesProcessor.filterSelfImports(from: content, outputFilename: "TestTypes.h")
+
+        XCTAssertEqual("#import <Foundation/Foundation.h>\n\n@interface Foo : NSObject\n@end\n\n", filtered)
+    }
+}


### PR DESCRIPTION

### Problem

Any Swift code that consumes a `single_file_codegen` module's generated
Obj-C bindings fails to import them. When a `swift_library` (or any clang
module build) tries to import the generated Types module, compilation fails
with:

```
error: 'deviceTypes/deviceTypes.h' file not found
error: could not build Objective-C module 'deviceTypes'
```

while the exact same generated sources compile fine as plain Obj-C. This makes
the generated modules unusable from Swift entirely — there is no workaround
from the consumer side, because the offending import is inside the generated
header itself. In valdi's own testdata (`//valdi/testdata/resources/modules/test`),
the merged output contains imports of itself, e.g. in `SCCTestTypes.h`:
`#import <SCCTestTypes/SCCTestTypes.h>` (3x) and `#import "SCCTestTypes.h"`,
and in `SCCTest.h`: `#import <SCCTest/SCCTest.h>` (3x).

### Root cause

Two emission sites import "the Types header" by name when a type is referenced:

- `ObjCCodeGenerator.ensureTypeAvailability` (Generation/ObjC/ObjCCodeGenerator.swift:233)
  adds `type.importHeaderStatement(kind:)` to the api and regular headers;
- `NativeSource.iosNativeSourcesFromGeneratedCode` (Models/NativeSource.swift:48–52)
  prepends the same statement to each generated per-type header.

`IOSType.importHeaderStatement(kind:)` (Parser/Models/ValdiRawDocument.swift:315)
renders that as the canonical `<MyModuleTypes/MyModuleTypes.h>` when the module
has an import prefix (or the quoted `"MyModuleTypes.h"` form without one).

Under `single_file_codegen`, `CombineNativeSourcesProcessor.mergeAnySources`
then merges all per-type headers **into that very file** — so the merged
`MyModuleTypes.h` ends up containing `#import <MyModuleTypes/MyModuleTypes.h>`,
an import of itself (once per merged input).

Regular Obj-C compilation never notices: per-target header maps resolve
`<MyModuleTypes/MyModuleTypes.h>` to the file being compiled, and `#import` is
include-once, so the self-import is a no-op. Clang **module** builds — which is
what Swift interop uses to import the generated module — do not receive header
maps, so the angled self-import cannot be resolved and module construction
fails at exactly that line.

### The fix

Filter self-referential import lines while merging, in
`CombineNativeSourcesProcessor.mergeAnySources`, via a new static helper
`filterSelfImports(from:outputFilename:)` that drops lines equal (after
whitespace trimming) to any of the three forms the emission sites can produce
for the merged output file `MyModuleTypes.h`:

```swift
let selfImports: Set<String> = [
    "#import <\(outputFilename)>",          // #import <MyModuleTypes.h>
    "#import \"\(outputFilename)\"",        // #import "MyModuleTypes.h"
    "#import <\(stem)/\(outputFilename)>",  // #import <MyModuleTypes/MyModuleTypes.h>
]
```

The comparison is on exact statement equality against the output filename, so
legitimate imports are untouched: `<Foundation/Foundation.h>`,
`<valdi_core/...>`, the main header inside the Types file (`SCCTest.h` →
`SCCTestTypes.h`), and vice versa. Removing a provable no-op cannot regress the
header-map-based ObjC path that works today.

### Evidence

End-to-end, as an out-of-tree consumer of generated modules (any Swift interop
consumer is affected the same way): with only this patch applied to the
compiler, a project using a generated `single_file_codegen` module implemented
against its generated bindings

1. built green through bazel (128 actions), where the same project previously
   failed in clang module construction on the self-import line;
2. produced a linked binary containing the module's generated symbols;
3. installed and launched on an iOS simulator; and
4. executed the module's `getId()` (returns `identifierForVendor`), returning a
   live UUID rendered by the app UI — proving the generated Obj-C module was
   imported and called through the Swift interop path.

Additionally:

- New unit tests cover the filter (`swift test` in `compiler/compiler/Compiler`
  — `CombineNativeSourcesProcessorTests`, 4 tests: all three self-import forms
  dropped, other-header imports kept, indented lines matched, and content
  without self-imports preserved byte-for-byte). Full suite: 20/20 pass.
  The tests caught a real defect during development (the quoted form was
  initially mis-escaped and not actually filtered).
- Regression checks with the patch applied (prebuilt-compiler mode):
  `bazel test //valdi/testdata/resources/modules/test:test_test` and
  `bazel build //valdi/testdata/resources/modules/test:test_cpp` both pass.

### Out of scope (deliberately not changed)

- The emission sites themselves (`ensureTypeAvailability`,
  `IOSType.importHeaderStatement`, `NativeSource` header prepending) — they are
  correct for non-merged output; only the merged file must not import itself.
- Header-map behavior and modulemap generation.
- Any change to `.m` merging (`mergeObjcSources`), Kotlin, C++, or other
  processors — the fix is isolated to the `.h` merge path.

---

