### PR TITLE
Add integration_test case: image intrinsic height drives container

### DIFF
--- a/apps/integration_test/src/valdi/integration_test_app/src/IntegrationTestCases.tsx
+++ b/apps/integration_test/src/valdi/integration_test_app/src/IntegrationTestCases.tsx
@@ -4813,6 +4813,29 @@ export const INTEGRATION_TEST_CASES: readonly IntegrationTestCase[] = [
       }
     },
   },
+  {
+    // An image sized width:100% with no explicit height must give its
+    // (auto-height) container an intrinsic height from the image aspect ratio.
+    // Web must not collapse the container to 0 height.
+    id: 'image-intrinsic-height-container',
+    name: 'Image intrinsic height drives container',
+    description:
+      'Image with width:100% and no explicit height inside an auto-height container; the container must take the image height, not collapse to zero.',
+    element: 'image',
+    render: (ctx: IntegrationTestRenderContext) => {
+      <view key={ctx.caseId} ref={ctx.rootRef} width={WIDTH} height={HEIGHT} backgroundColor={CARD} padding={16}>
+        <view backgroundColor="#FFFFFF" border="1 solid #CBD5E1" padding={12}>
+          <image
+            src={res.image}
+            width="100%"
+            objectFit="contain"
+            onImageDecoded={(w, h) => ctx.record(`intrinsic image decoded:${w}x${h}`)}
+            onAssetLoad={(success, error) => ctx.record(`intrinsic image asset:${success}:${error ?? ''}`)}
+          />
+        </view>
+      </view>;
+    },
+  },
 ];
 
 export type IntegrationCoverageLedgerElement = NativeTemplateElementName | 'slot';


### PR DESCRIPTION
Adds an `apps/integration_test` case that documents a web-renderer regression on this branch (#148): an `<image>` sized `width:"100%"` with **no explicit height** does not give its auto-height container any height. The image decodes but the container collapses to ~0, so the image is invisible.

### Root cause
`src/valdi_modules/src/valdi/web_renderer/src/elements/ImageElement.ts` (~L412/L435) sets the inner `<img>`/canvas to `position: absolute`, so it contributes no intrinsic height to the wrapper; with no explicit height the wrapper stays `auto` → 0. Native (and the previous web renderer, where the `<img>` was in flow) size the container from the image aspect ratio.

### Repro
Case `image-intrinsic-height-container` renders an intrinsic-ratio image in an auto-height card and records decode/asset observations. Web snapshot = a thin empty bar; native renders the image at its aspect-ratio height. The web-vs-native diff fails.

### Suggested fix
Give the wrapper an intrinsic height from the decoded aspect ratio when no explicit height is set (or keep the inner `<img>` in flow for that case).

This case passes once the wrapper takes the image's intrinsic height.
