### PR TITLE
Add integration_test case: scroll clips overflowing content

### DIFF
--- a/apps/integration_test/src/valdi/integration_test_app/src/IntegrationTestCases.tsx
+++ b/apps/integration_test/src/valdi/integration_test_app/src/IntegrationTestCases.tsx
@@ -4813,6 +4813,31 @@ export const INTEGRATION_TEST_CASES: readonly IntegrationTestCase[] = [
       }
     },
   },
+  {
+    // A scroll with content taller than its fixed height must clip (and scroll),
+    // not grow to its content height and push following siblings out of bounds.
+    id: 'scroll-overflow-clipping',
+    name: 'Scroll clips overflowing content',
+    description:
+      'Scroll with fixed height 200 containing 600px of content; the content must be clipped to the scroll bounds, and the sentinel below must stay on-canvas.',
+    element: 'scroll',
+    render: (ctx: IntegrationTestRenderContext) => {
+      <view key={ctx.caseId} ref={ctx.rootRef} width={WIDTH} height={HEIGHT} backgroundColor={CARD} padding={16}>
+        <scroll height={200} width="100%" backgroundColor="#FFFFFF" border="1 solid #CBD5E1">
+          <view height={600} backgroundColor="#DBEAFE" padding={12}>
+            <label value="Top of tall content — should be visible." numberOfLines={0} color="#1E3A8A" font="system 14" />
+          </view>
+        </scroll>
+        <label
+          value="Sentinel below the scroll — must not be pushed off by spillover."
+          numberOfLines={0}
+          color="#334155"
+          font="system 14"
+          width="100%"
+        />
+      </view>;
+    },
+  },
 ];
 
 export type IntegrationCoverageLedgerElement = NativeTemplateElementName | 'slot';


### PR DESCRIPTION
Adds an `apps/integration_test` case that documents a web-renderer regression on this branch (#148): a `<scroll>` with a fixed height renders at its **content** height instead of clipping/scrolling, so it overflows its bounds and pushes following siblings off-canvas.

### Root cause
`src/valdi_modules/src/valdi/web_renderer/src/elements/ScrollElementClass.ts` — the scroll box's own height + `overflow` aren't applied to constrain it, so it grows to content.

### Repro
Case `scroll-overflow-clipping` renders a `height=200` scroll over 600px of content plus a sentinel below it. Web: the scroll box renders ~600px and the sentinel is shoved down/off. Native: the scroll is 200px and content scrolls within it. The web-vs-native diff fails.

### Suggested fix
Apply the scroll element's own height + `overflow` so content is clipped/scrollable within the box.
