### PR TITLE
Add CollapseWebPaths test: transitive-dependency res must be registered

### DIFF
--- a/valdi/compiler/toolbox/test/CollapseWebPaths_tests.cpp
+++ b/valdi/compiler/toolbox/test/CollapseWebPaths_tests.cpp
@@ -208,6 +208,45 @@ TEST(CollapseWebPaths, appliesImageInliningPolicyPerModule) {
               "};\n");
 }
 
+// Transitive-dependency res is staged under a nested `release/res/<module>/res`
+// path, but generateImageRegistry only scans the immediate children of `src/`.
+// The transitive module's images are copied into the package yet never added to
+// _image_registry.js, so getAssets() cannot resolve them at runtime (icons render
+// blank). The registry must cover every module's res, including transitive deps.
+TEST(CollapseWebPaths, registersTransitiveDependencyResources) {
+    CollapseTemporaryDirectory directory;
+    auto directIcon = directory.write("inputs/direct_icon.png", "png\n");
+    auto transitiveIcon = directory.write("inputs/transitive_icon.png", "png\n");
+    auto manifest = directory.write("manifest.tsv",
+                                    fmt::format("{}\tsrc/lead/res/direct_icon.png\n"
+                                                "{}\tsrc/release/res/shared/res/transitive_icon.png\n",
+                                                directIcon,
+                                                transitiveIcon));
+    auto stringsManifest = directory.write("strings.tsv", "");
+    auto declarationsManifest = directory.write("declarations.tsv", "");
+    auto webWorkersManifest = directory.write("web-workers.tsv", "");
+    auto imagePolicyManifest = directory.write("image-policy.tsv", "");
+    auto output = directory.path().appending("output");
+
+    auto result = collapseWebPaths(output.toStringBox(),
+                                   manifest.toStringBox(),
+                                   StringCache::getGlobal().makeString(std::string_view("@scope/package")),
+                                   stringsManifest.toStringBox(),
+                                   declarationsManifest.toStringBox(),
+                                   webWorkersManifest.toStringBox(),
+                                   imagePolicyManifest.toStringBox());
+
+    ASSERT_TRUE(result) << result.description();
+    auto registry = directory.read("output/src/_image_registry.js");
+    // Direct dependency is registered today.
+    EXPECT_NE(registry.find("__r['lead/res']"), std::string::npos) << registry;
+    // Transitive dependency (staged under release/res/<module>/res) must also be
+    // registered. This fails on the current renderer: its icons are bundled but
+    // absent from the registry.
+    EXPECT_NE(registry.find("__r['shared/res']"), std::string::npos) << registry;
+    EXPECT_NE(registry.find("transitive_icon.png"), std::string::npos) << registry;
+}
+
 } // namespace
 
 } // namespace Valdi


### PR DESCRIPTION
Adds a `CollapseWebPaths` unit test that documents a regression on this branch (#148): **transitive-dependency `res/` images are copied into the web package but never registered in `_image_registry.js`**, so `getAssets()` can't resolve them at runtime and the icons render blank.

### Root cause
`valdi/compiler/toolbox/src/valdi/compiler_toolbox/CollapseWebPaths.cpp` `generateImageRegistry` (L274) scans only the **immediate children** of `src/` for `<module>/res` (`DiskUtils::listDirectory(sourceDirectory)`, L276). The collapse stages **direct**-dep res at top-level `src/<module>/res` (registered) but **transitive**-dep res at a nested `src/release/res/<module>/res` (never scanned). Observed on a real package: only the direct module appeared in `_image_registry.js`; ~20 `coreui` icons and other transitive res were bundled but unregistered.

### Repro
`TEST(CollapseWebPaths, registersTransitiveDependencyResources)` builds a package with a direct-dep res and a transitive-dep res (staged under `release/res/shared/res`) and asserts both appear in the registry. It fails on this branch because the transitive entry is dropped.

### Suggested fix
Enumerate `res` under the nested `release/res/<module>/res` locations too (or stage all module res uniformly at `src/<module>/res`), so the registry matches the full transitive web-dep closure.
