### PR TITLE
Support explicit debugger ports

### DIFF
--- a/npm_modules/cli/src/debugger/server.spec.ts
+++ b/npm_modules/cli/src/debugger/server.spec.ts
@@ -524,6 +524,26 @@ describe('debugger server', () => {
     expect(responseBody.logs.map(log => log.message)).toEqual(['exact application']);
   });
 
+  it('does not expose absolute log paths in filesystem error responses', async () => {
+    const logsDirectory = path.join(assetRoot, 'missing', 'logs');
+    const consoleWarn = spyOn(console, 'warn');
+    debuggerServer = await startDebuggerServer({
+      assetRoot,
+      host: '127.0.0.1',
+      logsDirectory,
+      port: await getFreePort(),
+      strictPort: true,
+    });
+
+    const result = await request(new URL('/api/runtime-logs', debuggerServer.url).toString(), GET_REQUEST_OPTIONS);
+    const responseBody = JSON.parse(result.body) as { error: string };
+
+    expect(result.statusCode).toBe(500);
+    expect(responseBody.error).toBe('A local filesystem operation failed. See the debugger server output for details.');
+    expect(result.body).not.toContain(logsDirectory);
+    expect(consoleWarn).toHaveBeenCalledWith(jasmine.stringContaining(logsDirectory));
+  });
+
   it('reads the logs directory through the shared YAML config parser', async () => {
     const testHome = path.join(assetRoot, 'home');
     const logsDirectory = path.join(testHome, 'logs#debug');

--- a/npm_modules/cli/src/debugger/server.ts
+++ b/npm_modules/cli/src/debugger/server.ts
@@ -254,6 +254,22 @@ function errorPayload(error: unknown): { error: string } {
   };
 }
 
+function isFileSystemError(error: unknown): error is NodeJS.ErrnoException {
+  if (!(error instanceof Error)) return false;
+  const fileSystemError = error as NodeJS.ErrnoException;
+  return (
+    typeof fileSystemError.code === 'string' &&
+    typeof fileSystemError.path === 'string' &&
+    typeof fileSystemError.syscall === 'string'
+  );
+}
+
+function clientErrorPayload(error: unknown): { error: string } {
+  if (!isFileSystemError(error)) return errorPayload(error);
+  console.warn(`Debugger filesystem error: ${errorPayload(error).error}`);
+  return { error: 'A local filesystem operation failed. See the debugger server output for details.' };
+}
+
 function isValidSnapshotBase64(value: string): boolean {
   if (!value || value.length % 4 === 1) return false;
   const firstPaddingIndex = value.indexOf('=');
@@ -841,7 +857,7 @@ async function streamRuntimeLogs(
 
       if (nextLogs.length > 0) sendSse(response, 'logs', { logs: nextLogs });
     } catch (error) {
-      sendSse(response, 'stream-error', errorPayload(error));
+      sendSse(response, 'stream-error', clientErrorPayload(error));
     }
   }
 
@@ -899,7 +915,7 @@ async function collectClientContexts(
       try {
         contexts = await conn.listContexts(client.client_id);
       } catch (error) {
-        contextError = errorPayload(error).error;
+        contextError = clientErrorPayload(error).error;
       }
     }
 
@@ -938,7 +954,7 @@ async function inspectPort(port: number): Promise<{
       portName: portName(port),
       connected: false,
       clients: [],
-      error: errorPayload(error).error,
+      error: clientErrorPayload(error).error,
     };
   }
 }
@@ -1375,7 +1391,7 @@ async function handleApi(request: IncomingMessage, response: ServerResponse, url
 
     sendJson(response, 404, { error: `Unknown API route ${url.pathname}` });
   } catch (error) {
-    sendJson(response, error instanceof ApiRequestError ? error.statusCode : 500, errorPayload(error));
+    sendJson(response, error instanceof ApiRequestError ? error.statusCode : 500, clientErrorPayload(error));
   }
 }
 

--- a/src/valdi_modules/src/valdi/valdi_core/test/IRenderedVirtualNodeData.spec.ts
+++ b/src/valdi_modules/src/valdi/valdi_core/test/IRenderedVirtualNodeData.spec.ts
@@ -190,6 +190,39 @@ describe('IRenderedVirtualNodeData', () => {
     expect(data.component?.viewModel).toContain('Set(');
   });
 
+  it('replaces values at the maximum component debug depth with an omission marker', () => {
+    const data = createDetailedData(
+      createComponentNode(
+        {
+          level1: { level2: { level3: { level4: 'too-deep' } } },
+          sibling: 'visible',
+        },
+        {},
+      ),
+    );
+
+    expect(data.component?.viewModel).toContain('level4: ...');
+    expect(data.component?.viewModel).not.toContain('too-deep');
+    expect(data.component?.viewModel).toContain('sibling: "visible"');
+  });
+
+  it('limits arrays and objects to 50 serialized items with omission markers', () => {
+    const items = Array.from({ length: 52 }, (_value, index) => `item-${index}`);
+    const properties: Record<string, number> = {};
+    for (let index = 0; index < 52; index++) {
+      properties[`property${index}`] = index;
+    }
+
+    const data = createDetailedData(createComponentNode({ items, properties }, {}));
+
+    expect(data.component?.viewModel).toContain('"item-49"');
+    expect(data.component?.viewModel).not.toContain('"item-50"');
+    expect(data.component?.viewModel).toContain('... 2 more item(s) ...');
+    expect(data.component?.viewModel).toContain('property49: 49');
+    expect(data.component?.viewModel).not.toContain('property50: 50');
+    expect(data.component?.viewModel).toContain('... more properties ...');
+  });
+
   it('truncates one serialized component field to its character cap', () => {
     const data = createDetailedData(createComponentNode('x'.repeat(70_000), {}));
 

--- a/valdi/BUILD.bazel
+++ b/valdi/BUILD.bazel
@@ -598,6 +598,7 @@ kt_jvm_test(
         "@android_mvn//:org_junit_vintage_junit_vintage_engine",
     ],
     deps = [
+        ":valdi_android_support",
         ":valdi_android_test_support",
         ":valdi_java",
         "//src/valdi_modules/src/valdi/valdi_test:valdi_test_kt",

--- a/valdi/src/android_support/java/com/snap/valdi/support/AppBootstrapActivity.kt
+++ b/valdi/src/android_support/java/com/snap/valdi/support/AppBootstrapActivity.kt
@@ -1,6 +1,9 @@
 package com.snap.valdi.support
 
+import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 
@@ -12,6 +15,12 @@ import com.snap.valdi.ValdiRuntimeManager
 import com.snap.valdi.ValdiRuntime
 import com.snap.valdi.utils.Disposable
 import com.snap.valdi.support.DefaultNavigator
+import com.snapchat.client.valdi.NativeBridge
+
+/** Intent extra used to select the Valdi debugger port for a debuggable application. */
+const val VALDI_DEBUGGER_PORT_INTENT_EXTRA = "com.snap.valdi.DEBUGGER_PORT"
+
+private const val VALDI_LOG_TAG = "Valdi"
 
 /**
   This class implements an Android activity where the root view
@@ -53,8 +62,29 @@ abstract class AppBootstrapActivity: AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        System.loadLibrary(getNativeLibName())
+        val debuggerPort = requestedValdiDebuggerPort(
+            intent,
+            applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0,
+        )
+        loadNativeLibrary()
+        if (debuggerPort != null) {
+            // This process-wide override intentionally persists for this debug host process. When the intent
+            // omits the extra, this block is skipped so externally configured environment state remains unchanged.
+            setDebuggerPortEnvironment(debuggerPort)
+        }
 
+        bootstrapValdiRuntime()
+    }
+
+    protected open fun loadNativeLibrary() {
+        System.loadLibrary(getNativeLibName())
+    }
+
+    protected open fun setDebuggerPortEnvironment(debuggerPort: Int) {
+        NativeBridge.setDebuggerPortEnvironment(debuggerPort)
+    }
+
+    protected open fun bootstrapValdiRuntime() {
         createRuntimeManager()
         this.rootView = createAppRootView()
         setContentView(this.rootView)
@@ -105,4 +135,22 @@ abstract class AppBootstrapActivity: AppCompatActivity() {
             super.onBackPressed()
         }
     }
+}
+
+internal fun requestedValdiDebuggerPort(intent: Intent?, debuggable: Boolean): Int? {
+    if (!debuggable || intent == null || !intent.hasExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA)) {
+        return null
+    }
+
+    val port = intent.extras?.get(VALDI_DEBUGGER_PORT_INTENT_EXTRA) as? Int
+    if (port == null || port !in 1..65535) {
+        Log.w(
+            VALDI_LOG_TAG,
+            "Ignoring invalid Valdi debugger port from intent extra " +
+                "$VALDI_DEBUGGER_PORT_INTENT_EXTRA: <redacted> (expected an integer in 1...65535)",
+        )
+        return null
+    }
+
+    return port
 }

--- a/valdi/src/java/com/snapchat/client/valdi/NativeBridge.java
+++ b/valdi/src/java/com/snapchat/client/valdi/NativeBridge.java
@@ -4,6 +4,7 @@ import com.snap.valdi.callable.ValdiFunction;
 
 public class NativeBridge {
     public static native int getBuildOptions();
+    public static native void setDebuggerPortEnvironment(int debuggerPort);
     public static native long createRuntimeManager(Object mainThreadDispatcher,
                                                       Object snapDrawingFrameScheduler,
                                                       Object viewManager,

--- a/valdi/src/valdi/android/NativeBridge.cpp
+++ b/valdi/src/valdi/android/NativeBridge.cpp
@@ -62,6 +62,8 @@
 #endif
 
 #include <android/native_window_jni.h>
+#include <cstdlib>
+#include <string>
 
 inline ValdiAndroid::RuntimeWrapper* getRuntimeWrapper(jlong handle) {
     return reinterpret_cast<ValdiAndroid::RuntimeWrapper*>(handle);
@@ -146,6 +148,12 @@ jint ValdiAndroid::NativeBridge::getBuildOptions(fbjni::alias_ref<fbjni::JClass>
 #endif
 
     return static_cast<jint>(buildOptions);
+}
+
+void ValdiAndroid::NativeBridge::setDebuggerPortEnvironment(fbjni::alias_ref<fbjni::JClass> /* clazz */,
+                                                            jint debuggerPort) {
+    const auto debuggerPortString = std::to_string(debuggerPort);
+    setenv("VALDI_DEBUGGER_PORT", debuggerPortString.c_str(), 1);
 }
 
 jlong ValdiAndroid::NativeBridge::createRuntimeManager( // NOLINT
@@ -2530,6 +2538,7 @@ jlong ValdiAndroid::NativeBridge::snapDrawingGetMaxRenderTargetSize(fbjni::alias
 void ValdiAndroid::NativeBridge::registerNatives() {
     javaClassStatic()->registerNatives({
         makeNativeMethod("getBuildOptions", ValdiAndroid::NativeBridge::getBuildOptions),
+        makeNativeMethod("setDebuggerPortEnvironment", ValdiAndroid::NativeBridge::setDebuggerPortEnvironment),
         makeNativeMethod("getAllRuntimeAttachedObjects", ValdiAndroid::NativeBridge::getAllRuntimeAttachedObjects),
         makeNativeMethod("prepareRenderBackend", ValdiAndroid::NativeBridge::prepareRenderBackend),
         makeNativeMethod("emitRuntimeManagerInitMetrics", ValdiAndroid::NativeBridge::emitRuntimeManagerInitMetrics),

--- a/valdi/src/valdi/android/NativeBridge.hpp
+++ b/valdi/src/valdi/android/NativeBridge.hpp
@@ -16,6 +16,7 @@ public:
     static constexpr auto kJavaDescriptor = "Lcom/snapchat/client/valdi/NativeBridge;";
 
     static jint getBuildOptions(fbjni::alias_ref<fbjni::JClass> clazz);
+    static void setDebuggerPortEnvironment(fbjni::alias_ref<fbjni::JClass> clazz, jint debuggerPort);
 
     static jobject getAllRuntimeAttachedObjects(fbjni::alias_ref<fbjni::JClass> clazz, jlong runtimeManagerHandle);
 

--- a/valdi/src/valdi/android/RuntimeManagerWrapper.cpp
+++ b/valdi/src/valdi/android/RuntimeManagerWrapper.cpp
@@ -104,7 +104,8 @@ RuntimeManagerWrapper::RuntimeManagerWrapper(JavaEnv env,
                                                                    _logger,
                                                                    /* enableDebuggerService */ true,
                                                                    /* disableHotReloader */ false,
-                                                                   /* isStandalone */ false);
+                                                                   /* isStandalone */ false,
+                                                                   std::nullopt);
         _runtimeManager->postInit();
         _runtimeManager->setKeepDebuggerServiceOnPause(static_cast<bool>(keepDebuggerServiceOnPause));
         _runtimeManager->setApplicationId(_applicationId);

--- a/valdi/src/valdi/ios/Bootstrap/SCValdiBootstrappingAppDelegate.m
+++ b/valdi/src/valdi/ios/Bootstrap/SCValdiBootstrappingAppDelegate.m
@@ -14,10 +14,12 @@
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
 {
-    _runtimeManager = [[SCValdiRuntimeManager alloc] init];
+    _runtimeManager = [SCValdiRuntimeManager new];
 
     [_runtimeManager updateConfiguration:^(SCValdiConfiguration* configuration) {
         configuration.allowDarkMode = YES;
+        // Bootstrap apps are local-development hosts, so keep their previous hot-reload behavior explicit.
+        configuration.enableDebuggerService = YES;
     }];
 
     id<SCValdiRuntimeProtocol> runtime = _runtimeManager.mainRuntime;

--- a/valdi/src/valdi/ios/SCValdiRuntimeManager.mm
+++ b/valdi/src/valdi/ios/SCValdiRuntimeManager.mm
@@ -88,6 +88,20 @@ static id<SCNValdiKeychain> SCValdiCreateKeychainStore() {
     #endif
 }
 
+static std::optional<uint32_t> SCValdiResolveDebuggerServicePort(SCValdiConfiguration* configuration) {
+    NSInteger debuggerServicePort = configuration.debuggerServicePort;
+    if (debuggerServicePort == 0) {
+        return std::nullopt;
+    }
+
+    if (debuggerServicePort < 0 || debuggerServicePort > 65535) {
+        SCLogValdiWarning(@"Ignoring invalid Valdi debugger service port: <redacted> (expected 1...65535)");
+        return std::nullopt;
+    }
+
+    return static_cast<uint32_t>(debuggerServicePort);
+}
+
 static void updateRuntimeManagersArray(void (^callback)(NSMutableArray<NSValue *> *runtimeManagers)) {
     static dispatch_once_t onceToken;
     static NSMutableArray<NSValue *> *kAllRuntimeManagers;
@@ -204,6 +218,7 @@ static void updateRuntimeManagersArray(void (^callback)(NSMutableArray<NSValue *
         _diskCache = Valdi::makeShared<Valdi::DiskCacheImpl>(resolveDocumentsDirectory());
 
         id<SCNValdiKeychain> keychainStore = SCValdiCreateKeychainStore();
+        SCValdiConfiguration *configuration = [self _getOrCreateConfiguration];
 
         _cppInstance = Valdi::makeShared<Valdi::RuntimeManager>(mainThreadDispatcher,
                                                                      [self _javaScriptBridge],
@@ -213,9 +228,10 @@ static void updateRuntimeManagersArray(void (^callback)(NSMutableArray<NSValue *
                                                                      Valdi::PlatformTypeIOS,
                                                                      Valdi::ThreadQoSClassMax,
                                                                      logger,
-                                                                     /* enableDebuggerService */ true,
-                                                                     /* disableHotReloader */ false,
-                                                                     /* isStandalone */ false);
+                                                                     configuration.enableDebuggerService,
+                                                                     configuration.disableHotReloader,
+                                                                     /* isStandalone */ false,
+                                                                     SCValdiResolveDebuggerServicePort(configuration));
         _cppInstance->postInit();
         NSString *bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
         _cppInstance->setApplicationId(ValdiIOS::StringFromNSString(bundleIdentifier));

--- a/valdi/src/valdi/macos/SCValdiRuntime.mm
+++ b/valdi/src/valdi/macos/SCValdiRuntime.mm
@@ -117,7 +117,8 @@ public:
                                                                                Valdi::strongSmallRef(&Valdi::ConsoleLogger::getLogger()),
                                                                                /* enableDebuggerService */ true,
                                                                                /* disableHotReloader */ false,
-                                                                               /* isStandalone */ true);
+                                                                               /* isStandalone */ true,
+                                                                               std::nullopt);
         _runtimeManager->postInit();
         _runtimeManager->applicationDidResume();
         _runtimeManager->registerBytesAssetLoader(cachesImageCache);

--- a/valdi/src/valdi/runtime/Debugger/DebuggerService.cpp
+++ b/valdi/src/valdi/runtime/Debugger/DebuggerService.cpp
@@ -18,6 +18,11 @@
 
 #include "valdi_core/cpp/Utils/ContainerUtils.hpp"
 
+#include <charconv>
+#include <cstdlib>
+#include <cstring>
+#include <system_error>
+
 namespace Valdi {
 
 class DaemonClientTCPDataSender : public DaemonClientDataSender {
@@ -136,6 +141,10 @@ void DebuggerService::stop() {
             VALDI_INFO(*_logger, "Stopped Valdi debugger service");
         }
     });
+}
+
+uint32_t DebuggerService::getConfiguredPort() const {
+    return _debuggerPort;
 }
 
 uint16_t DebuggerService::getBoundPort() {
@@ -314,6 +323,45 @@ Ref<ILogger> DebuggerService::getBridgeLogger() const {
 
 uint32_t DebuggerService::resolveDebuggerPort(bool isStandalone) {
     return isStandalone ? kStandaloneDebuggerPort : kMobileDebuggerPort;
+}
+
+DebuggerPortResolution DebuggerService::resolveDebuggerPortWithDiagnostics(
+    bool isStandalone,
+    std::optional<uint32_t> requestedPort) {
+    DebuggerPortResolution resolution{
+        resolveDebuggerPort(isStandalone),
+        std::nullopt,
+        std::nullopt,
+    };
+
+    if (requestedPort.has_value()) {
+        if (requestedPort.value() > 0 && requestedPort.value() <= 65535) {
+            resolution.port = requestedPort.value();
+            return resolution;
+        }
+        resolution.rejectedRequestedPort = requestedPort;
+    }
+
+    const char* overridePort = std::getenv("VALDI_DEBUGGER_PORT");
+    if (overridePort != nullptr) {
+        uint32_t parsedPort = 0;
+        const char* overridePortEnd = overridePort + std::strlen(overridePort);
+        const auto parseResult = std::from_chars(overridePort, overridePortEnd, parsedPort);
+        if (parseResult.ec == std::errc() && parseResult.ptr == overridePortEnd && parsedPort > 0 &&
+            parsedPort <= 65535) {
+            resolution.port = parsedPort;
+            return resolution;
+        }
+
+        if (parseResult.ec == std::errc::result_out_of_range ||
+            (parseResult.ec == std::errc() && parseResult.ptr == overridePortEnd)) {
+            resolution.environmentError = DebuggerPortEnvironmentError::OutOfRange;
+        } else {
+            resolution.environmentError = DebuggerPortEnvironmentError::Malformed;
+        }
+    }
+
+    return resolution;
 }
 
 } // namespace Valdi

--- a/valdi/src/valdi/runtime/Debugger/DebuggerService.hpp
+++ b/valdi/src/valdi/runtime/Debugger/DebuggerService.hpp
@@ -18,6 +18,7 @@
 
 #include "utils/platform/BuildOptions.hpp"
 
+#include <optional>
 #include <vector>
 
 namespace snap::valdi {
@@ -35,6 +36,17 @@ class DebuggerService;
 class Runtime;
 
 class IDebuggerServiceListener;
+
+enum class DebuggerPortEnvironmentError {
+    Malformed,
+    OutOfRange,
+};
+
+struct DebuggerPortResolution {
+    uint32_t port;
+    std::optional<uint32_t> rejectedRequestedPort;
+    std::optional<DebuggerPortEnvironmentError> environmentError;
+};
 
 class DebuggerService : public SharedPtrRefCountable,
                         protected ITCPServerListener,
@@ -67,9 +79,12 @@ public:
     StringBox getApplicationId() const;
     void setApplicationId(const StringBox& applicationId);
 
+    uint32_t getConfiguredPort() const;
     uint16_t getBoundPort();
 
     static uint32_t resolveDebuggerPort(bool isStandalone);
+    static DebuggerPortResolution resolveDebuggerPortWithDiagnostics(bool isStandalone,
+                                                                     std::optional<uint32_t> requestedPort);
 
 protected:
     // TCPServerListener

--- a/valdi/src/valdi/runtime/RuntimeManager.cpp
+++ b/valdi/src/valdi/runtime/RuntimeManager.cpp
@@ -43,6 +43,7 @@ namespace Valdi {
 Shared<DebuggerService> createDebuggerService(bool enableDebuggerService,
                                               bool disableHotReloader,
                                               bool isStandalone,
+                                              std::optional<uint32_t> debuggerPort,
                                               PlatformType platformType,
                                               const Shared<snap::valdi::RuntimeMessageHandler>& runtimeMessageHandler,
                                               const Ref<ILogger>& logger) {
@@ -65,10 +66,25 @@ Shared<DebuggerService> createDebuggerService(bool enableDebuggerService,
                 platform = snap::valdi_core::Platform::Ios;
                 break;
         }
-        auto debuggerPort = DebuggerService::resolveDebuggerPort(isStandalone);
+        auto debuggerPortResolution =
+            DebuggerService::resolveDebuggerPortWithDiagnostics(isStandalone, debuggerPort);
+        if (debuggerPortResolution.rejectedRequestedPort.has_value()) {
+            VALDI_WARN(*logger,
+                       "Ignoring invalid debugger port from requestedPort: <redacted> (expected 1...65535); "
+                       "trying VALDI_DEBUGGER_PORT, then the platform default.");
+        }
+        if (debuggerPortResolution.environmentError.has_value()) {
+            VALDI_WARN(*logger,
+                       "Ignoring invalid debugger port from VALDI_DEBUGGER_PORT: <redacted {} value> (expected "
+                       "1...65535); using platform default {}.",
+                       debuggerPortResolution.environmentError.value() == DebuggerPortEnvironmentError::OutOfRange
+                           ? "out-of-range"
+                           : "malformed",
+                       debuggerPortResolution.port);
+        }
 
         auto debuggerService = Valdi::makeShared<DebuggerService>(
-            runtimeMessageHandler, platform, debuggerPort, disableHotReloader, logger);
+            runtimeMessageHandler, platform, debuggerPortResolution.port, disableHotReloader, logger);
         debuggerService->postInit();
         return debuggerService.toShared();
     } else {
@@ -117,10 +133,41 @@ RuntimeManager::RuntimeManager(const Ref<IMainThreadDispatcher>& mainThreadDispa
                                bool enableDebuggerService,
                                bool disableHotReloader,
                                bool isStandalone)
+    : RuntimeManager(mainThreadDispatcher,
+                     jsBridge,
+                     diskCache,
+                     std::move(keychain),
+                     runtimeMessageHandler,
+                     platformType,
+                     jsThreadQoS,
+                     logger,
+                     enableDebuggerService,
+                     disableHotReloader,
+                     isStandalone,
+                     std::nullopt) {}
+
+RuntimeManager::RuntimeManager(const Ref<IMainThreadDispatcher>& mainThreadDispatcher,
+                               IJavaScriptBridge* jsBridge,
+                               const Ref<IDiskCache>& diskCache,
+                               Shared<snap::valdi::Keychain> keychain,
+                               const Shared<snap::valdi::RuntimeMessageHandler>& runtimeMessageHandler,
+                               PlatformType platformType,
+                               ThreadQoSClass jsThreadQoS,
+                               const Ref<ILogger>& logger,
+                               bool enableDebuggerService,
+                               bool disableHotReloader,
+                               bool isStandalone,
+                               std::optional<uint32_t> debuggerPort)
     : _initStopWatch(std::make_shared<MetricsStopWatch>()),
       _yogaConfig(Valdi::Yoga::createConfig(0)),
       _debuggerService(createDebuggerService(
-          enableDebuggerService, disableHotReloader, isStandalone, platformType, runtimeMessageHandler, logger)),
+          enableDebuggerService,
+          disableHotReloader,
+          isStandalone,
+          debuggerPort,
+          platformType,
+          runtimeMessageHandler,
+          logger)),
       _deferredGCTask(DispatchQueue::TaskIDNull),
       _mainThreadManager(makeShared<MainThreadManager>(mainThreadDispatcher)),
       _assetLoaderManager(makeShared<AssetLoaderManager>()),
@@ -455,6 +502,13 @@ void RuntimeManager::setRequestManager(const Shared<snap::valdi_core::HTTPReques
 
 bool RuntimeManager::debuggerServiceEnabled() const {
     return _debuggerService != nullptr;
+}
+
+std::optional<uint32_t> RuntimeManager::getDebuggerServicePort() const {
+    if (_debuggerService == nullptr) {
+        return std::nullopt;
+    }
+    return _debuggerService->getConfiguredPort();
 }
 
 void RuntimeManager::setUserSession(const StringBox& userId) {

--- a/valdi/src/valdi/runtime/RuntimeManager.hpp
+++ b/valdi/src/valdi/runtime/RuntimeManager.hpp
@@ -19,6 +19,7 @@
 #include "valdi_core/cpp/Utils/Mutex.hpp"
 #include "valdi_core/cpp/Utils/Shared.hpp"
 #include <atomic>
+#include <optional>
 #include <vector>
 
 struct YGConfig;
@@ -74,6 +75,18 @@ public:
                    bool enableDebuggerService,
                    bool disableHotReloader,
                    bool isStandalone);
+    RuntimeManager(const Ref<IMainThreadDispatcher>& mainThreadDispatcher,
+                   IJavaScriptBridge* jsBridge,
+                   const Ref<IDiskCache>& diskCache,
+                   Shared<snap::valdi::Keychain> keychain,
+                   const Shared<snap::valdi::RuntimeMessageHandler>& runtimeMessageHandler,
+                   PlatformType platformType,
+                   ThreadQoSClass jsThreadQoS,
+                   const Ref<ILogger>& logger,
+                   bool enableDebuggerService,
+                   bool disableHotReloader,
+                   bool isStandalone,
+                   std::optional<uint32_t> debuggerPort);
     ~RuntimeManager() override;
 
     void postInit();
@@ -112,6 +125,7 @@ public:
     void applicationWillTerminate();
 
     bool debuggerServiceEnabled() const;
+    std::optional<uint32_t> getDebuggerServicePort() const;
 
     void setUserSession(const StringBox& userId);
     void setApplicationId(const StringBox& applicationId);

--- a/valdi/src/valdi/standalone_runtime/ValdiStandaloneRuntime.cpp
+++ b/valdi/src/valdi/standalone_runtime/ValdiStandaloneRuntime.cpp
@@ -403,7 +403,8 @@ Ref<ValdiStandaloneRuntime> ValdiStandaloneRuntime::create(bool enableDebuggerSe
                                                             Valdi::strongSmallRef(&ConsoleLogger::getLogger()),
                                                             enableDebuggerService,
                                                             disableHotReloader,
-                                                            /* isStandalone */ true);
+                                                            /* isStandalone */ true,
+                                                            std::nullopt);
     runtimeManager->postInit();
     runtimeManager->registerBytesAssetLoader(diskCache);
     auto shouldWaitForHotReload = enableDebuggerService && !disableHotReloader;

--- a/valdi/src/valdi/swift/SwiftValdiRuntimeManager.mm
+++ b/valdi/src/valdi/swift/SwiftValdiRuntimeManager.mm
@@ -10,7 +10,11 @@
 
 - (id<SCValdiRuntimeManagerProtocol>)createRuntimeManager {
     if (!self.runtimeManager) {
-        self.runtimeManager = [[SCValdiRuntimeManager alloc] init];
+        self.runtimeManager = [SCValdiRuntimeManager new];
+        [self.runtimeManager updateConfiguration:^(SCValdiConfiguration* configuration) {
+            // Preserve Snap's default-on development-host behavior; direct hosts can opt out through configuration.
+            configuration.enableDebuggerService = YES;
+        }];
     }
     return self.runtimeManager;
 }

--- a/valdi/test/ios/SCValdiRuntimeTests.mm
+++ b/valdi/test/ios/SCValdiRuntimeTests.mm
@@ -18,11 +18,14 @@
 #import "valdi/ios/Text/SCValdiCustomUnderlineStyle.h"
 #import "valdi/ios/Gestures/SCValdiGestureRecognizers.h"
 #import "valdi/ios/Utils/SCValdiImageFilter.h"
+#import "valdi/runtime/Debugger/DebuggerService.hpp"
+#import "valdi/runtime/RuntimeManager.hpp"
 #import "valdi/runtime/Utils/AsyncGroup.hpp"
 #import "valdi_core/cpp/Threading/DispatchQueue.hpp"
 #import "valdi_core/cpp/Threading/GCDDispatchQueue.hpp"
 #import "valdi_core/SCValdiScrollView.h"
 #import "valdi_core/SCValdiRootView.h"
+#import "valdi_core/SCValdiSharedLogger.h"
 #import "valdi_core/UIView+ValdiBase.h"
 
 #import <SCCValdiTest/SCCValdiTest.h>
@@ -49,6 +52,56 @@
 {
     if (self.onRenderCallback) {
         self.onRenderCallback();
+    }
+}
+
+@end
+
+@interface SCValdiCapturingLogger: NSObject<SCValdiLogger>
+
+- (void)reset;
+- (NSArray<NSString *> *)capturedMessages;
+
+@end
+
+@implementation SCValdiCapturingLogger {
+    NSMutableArray<NSString *> *_messages;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _messages = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (BOOL)isLogEnabledForLevel:(SCValdiLoggerLevel)level
+{
+    (void)level;
+    return YES;
+}
+
+- (void)outputLog:(NSString *)log forLevel:(SCValdiLoggerLevel)level
+{
+    (void)level;
+    @synchronized (self) {
+        [_messages addObject:log];
+    }
+}
+
+- (void)reset
+{
+    @synchronized (self) {
+        [_messages removeAllObjects];
+    }
+}
+
+- (NSArray<NSString *> *)capturedMessages
+{
+    @synchronized (self) {
+        return [_messages copy];
     }
 }
 
@@ -104,6 +157,86 @@
 - (void)tearDown
 {
     self.runtimeManager = nil;
+}
+
+- (Valdi::RuntimeManager *)_cppRuntimeManagerForRuntimeManager:(SCValdiRuntimeManager *)runtimeManager
+{
+    (void)runtimeManager.mainRuntime;
+    return static_cast<Valdi::RuntimeManager *>(runtimeManager.cppInstance);
+}
+
+- (void)testDirectRuntimeManagerPreservesDebuggerServiceDefault
+{
+    Valdi::RuntimeManager *runtimeManagerCpp = [self _cppRuntimeManagerForRuntimeManager:self.runtimeManager];
+
+    XCTAssertNotEqual(nullptr, runtimeManagerCpp);
+    XCTAssertEqual(Valdi::kDebuggerServiceEnabled, runtimeManagerCpp->debuggerServiceEnabled());
+}
+
+- (void)testDirectRuntimeManagerCanExplicitlyDisableDebuggerService
+{
+    SCValdiRuntimeManager *runtimeManager = [SCValdiRuntimeManager new];
+    [runtimeManager updateConfiguration:^(SCValdiConfiguration *configuration) {
+        configuration.enableDebuggerService = NO;
+    }];
+
+    Valdi::RuntimeManager *runtimeManagerCpp = [self _cppRuntimeManagerForRuntimeManager:runtimeManager];
+
+    XCTAssertNotEqual(nullptr, runtimeManagerCpp);
+    XCTAssertFalse(runtimeManagerCpp->debuggerServiceEnabled());
+}
+
+- (void)testDirectRuntimeManagerAcceptsExplicitDebuggerServicePort
+{
+    SCValdiRuntimeManager *runtimeManager = [SCValdiRuntimeManager new];
+    [runtimeManager updateConfiguration:^(SCValdiConfiguration *configuration) {
+        configuration.debuggerServicePort = 13702;
+    }];
+
+    Valdi::RuntimeManager *runtimeManagerCpp = [self _cppRuntimeManagerForRuntimeManager:runtimeManager];
+
+    XCTAssertNotEqual(nullptr, runtimeManagerCpp);
+    XCTAssertEqual(Valdi::kDebuggerServiceEnabled, runtimeManagerCpp->debuggerServiceEnabled());
+    std::optional<uint32_t> configuredPort = runtimeManagerCpp->getDebuggerServicePort();
+    if (Valdi::kDebuggerServiceEnabled) {
+        XCTAssertTrue(configuredPort.has_value());
+        XCTAssertEqual((uint32_t)13702, configuredPort.value_or(0));
+    } else {
+        XCTAssertFalse(configuredPort.has_value());
+    }
+}
+
+- (void)testInvalidExplicitDebuggerServicePortWarningIsValueRedacted
+{
+    id<SCValdiLogger> previousLogger = SCValdiGetSharedLogger();
+    SCValdiCapturingLogger *logger = [SCValdiCapturingLogger new];
+    SCValdiSetSharedLogger(logger);
+
+    @try {
+        for (NSNumber *invalidPort in @[@(-1), @(65536)]) {
+            [logger reset];
+            @autoreleasepool {
+                SCValdiRuntimeManager *runtimeManager = [SCValdiRuntimeManager new];
+                [runtimeManager updateConfiguration:^(SCValdiConfiguration *configuration) {
+                    configuration.debuggerServicePort = invalidPort.integerValue;
+                }];
+                (void)runtimeManager.mainRuntime;
+            }
+
+            NSString *warning = nil;
+            for (NSString *message in [logger capturedMessages]) {
+                if ([message containsString:@"Ignoring invalid Valdi debugger service port"]) {
+                    warning = message;
+                    break;
+                }
+            }
+            XCTAssertNotNil(warning);
+            XCTAssertTrue([warning containsString:@"<redacted>"]);
+            XCTAssertFalse([warning containsString:invalidPort.stringValue]);
+        }
+    } @finally {
+        SCValdiSetSharedLogger(previousLogger);
+    }
 }
 
 - (void)testRelativeLineHeightScalesNaturalLineHeightViaMultiple

--- a/valdi/test/java/support/AppBootstrapActivityTest.kt
+++ b/valdi/test/java/support/AppBootstrapActivityTest.kt
@@ -1,0 +1,161 @@
+package com.snap.valdi.support
+
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.util.Log
+import com.snap.valdi.views.ValdiRootView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+
+class TestAppBootstrapActivity : AppBootstrapActivity() {
+    val lifecycleEvents = mutableListOf<String>()
+
+    override fun createRootView(bootstrapper: AppBootstrapper): ValdiRootView {
+        error("Runtime bootstrap is replaced by the test seam")
+    }
+
+    protected override fun loadNativeLibrary() {
+        lifecycleEvents += "loadNativeLibrary"
+    }
+
+    protected override fun setDebuggerPortEnvironment(debuggerPort: Int) {
+        lifecycleEvents += "setDebuggerPortEnvironment:$debuggerPort"
+    }
+
+    protected override fun bootstrapValdiRuntime() {
+        lifecycleEvents += "bootstrapValdiRuntime"
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [19], manifest = Config.NONE)
+class AppBootstrapActivityTest {
+
+    @Before
+    fun clearLogs() {
+        ShadowLog.clear()
+    }
+
+    @Test
+    fun debuggerPortOverrideIsAvailableOnlyToDebuggableApplications() {
+        val intent = Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, 13644)
+        val wrongTypedIntent = Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, "secret-port-value")
+
+        assertEquals(13644, invokeRequestedValdiDebuggerPort(intent, true))
+        assertNull(invokeRequestedValdiDebuggerPort(intent, false))
+        assertNull(invokeRequestedValdiDebuggerPort(wrongTypedIntent, false))
+        assertTrue(valdiWarnings().isEmpty())
+    }
+
+    @Test
+    fun acceptsDebuggerPortBoundaries() {
+        assertEquals(
+            1,
+            invokeRequestedValdiDebuggerPort(
+                Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, 1),
+                true,
+            ),
+        )
+        assertEquals(
+            65535,
+            invokeRequestedValdiDebuggerPort(
+                Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, 65535),
+                true,
+            ),
+        )
+    }
+
+    @Test
+    fun absentDebuggerPortOverrideDoesNotWarn() {
+        assertNull(invokeRequestedValdiDebuggerPort(null, true))
+        assertNull(invokeRequestedValdiDebuggerPort(Intent(), true))
+
+        assertTrue(valdiWarnings().isEmpty())
+    }
+
+    @Test
+    fun invalidDebuggerPortOverridesWarnOnceWithRedactedValues() {
+        val invalidIntents = listOf(
+            Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, -1),
+            Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, 0),
+            Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, 65536),
+            Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, "secret-port-value"),
+        )
+
+        invalidIntents.forEach { intent ->
+            ShadowLog.clear()
+
+            assertNull(invokeRequestedValdiDebuggerPort(intent, true))
+
+            val warnings = valdiWarnings()
+            assertEquals(1, warnings.size)
+            assertTrue(warnings.single().contains("<redacted>"))
+            assertFalse(warnings.single().contains("secret-port-value"))
+        }
+    }
+
+    @Test
+    fun onCreateAppliesValidDebuggerPortAfterLibraryLoadOnApi19() {
+        val activity = createActivity(
+            Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, 13702),
+            debuggable = true,
+        )
+
+        assertEquals(
+            listOf("loadNativeLibrary", "setDebuggerPortEnvironment:13702", "bootstrapValdiRuntime"),
+            activity.lifecycleEvents,
+        )
+        assertTrue(valdiWarnings().isEmpty())
+    }
+
+    @Test
+    fun onCreateNeverAppliesAbsentInvalidWrongTypedOrNonDebuggableOverrides() {
+        val cases = listOf(
+            Triple(Intent(), true, 0),
+            Triple(Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, -1), true, 1),
+            Triple(Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, 65536), true, 1),
+            Triple(Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, "secret-port-value"), true, 1),
+            Triple(Intent().putExtra(VALDI_DEBUGGER_PORT_INTENT_EXTRA, 13702), false, 0),
+        )
+
+        cases.forEach { (intent, debuggable, expectedWarnings) ->
+            ShadowLog.clear()
+
+            val activity = createActivity(intent, debuggable)
+
+            assertEquals(listOf("loadNativeLibrary", "bootstrapValdiRuntime"), activity.lifecycleEvents)
+            assertEquals(expectedWarnings, valdiWarnings().size)
+            assertFalse(valdiWarnings().any { it.contains("secret-port-value") })
+        }
+    }
+
+    private fun valdiWarnings(): List<String> =
+        ShadowLog.getLogsForTag("Valdi").filter { it.type == Log.WARN }.map { it.msg }
+
+    private fun invokeRequestedValdiDebuggerPort(intent: Intent?, debuggable: Boolean): Int? =
+        Class.forName("com.snap.valdi.support.AppBootstrapActivityKt")
+            .getDeclaredMethod("requestedValdiDebuggerPort", Intent::class.java, Boolean::class.java)
+            .invoke(null, intent, debuggable) as Int?
+
+    private fun createActivity(intent: Intent, debuggable: Boolean): TestAppBootstrapActivity {
+        val controller = Robolectric.buildActivity(TestAppBootstrapActivity::class.java, intent)
+        val activity = controller.get()
+        activity.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+        activity.applicationInfo.flags = if (debuggable) {
+            activity.applicationInfo.flags or ApplicationInfo.FLAG_DEBUGGABLE
+        } else {
+            activity.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE.inv()
+        }
+        controller.create()
+        return activity
+    }
+}

--- a/valdi/test/runtime/DebuggerService_tests.cpp
+++ b/valdi/test/runtime/DebuggerService_tests.cpp
@@ -22,6 +22,7 @@
 #include "valdi_core/cpp/Utils/LoggerUtils.hpp"
 #include "valdi_core/cpp/Utils/Mutex.hpp"
 
+#include <cstdlib>
 #include <gtest/gtest.h>
 
 using namespace Valdi;
@@ -153,6 +154,36 @@ struct MockTCPClientListener : public ITCPClientListener, public MockListener<TC
     }
 };
 
+class ScopedEnvironmentVariable {
+public:
+    explicit ScopedEnvironmentVariable(const char* key) : _key(key) {
+        const char* existingValue = std::getenv(_key);
+        if (existingValue != nullptr) {
+            _existingValue = existingValue;
+        }
+    }
+
+    ~ScopedEnvironmentVariable() {
+        if (_existingValue.has_value()) {
+            setenv(_key, _existingValue->c_str(), 1);
+        } else {
+            unsetenv(_key);
+        }
+    }
+
+    void set(const char* value) {
+        setenv(_key, value, 1);
+    }
+
+    void unset() {
+        unsetenv(_key);
+    }
+
+private:
+    const char* _key;
+    std::optional<std::string> _existingValue;
+};
+
 struct DebuggerServiceWrapper {
     Ref<MockDebuggerServiceListener> listener;
     Shared<DebuggerService> service;
@@ -221,6 +252,118 @@ TEST(DebuggerService, canConnectAndDisconnect) {
     ASSERT_EQ(DebuggerServiceEventTypeDaemonClientDisconnected, daemonClientDisconnected.type);
 
     client->disconnect();
+}
+
+TEST(DebuggerService, resolveDebuggerPortUsesPlatformDefaults) {
+    ScopedEnvironmentVariable debuggerPortEnv("VALDI_DEBUGGER_PORT");
+    debuggerPortEnv.unset();
+
+    auto mobileResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(false, std::nullopt);
+    auto standaloneResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(true, std::nullopt);
+
+    ASSERT_EQ(static_cast<uint32_t>(13592), mobileResolution.port);
+    ASSERT_FALSE(mobileResolution.rejectedRequestedPort.has_value());
+    ASSERT_FALSE(mobileResolution.environmentError.has_value());
+    ASSERT_EQ(static_cast<uint32_t>(13591), standaloneResolution.port);
+    ASSERT_FALSE(standaloneResolution.rejectedRequestedPort.has_value());
+    ASSERT_FALSE(standaloneResolution.environmentError.has_value());
+}
+
+TEST(DebuggerService, legacyResolveDebuggerPortRemainsCallableAndUsesPlatformDefaults) {
+    ScopedEnvironmentVariable debuggerPortEnv("VALDI_DEBUGGER_PORT");
+    debuggerPortEnv.set("14000");
+
+    uint32_t (*legacyResolver)(bool) = &DebuggerService::resolveDebuggerPort;
+
+    ASSERT_EQ(static_cast<uint32_t>(13592), legacyResolver(false));
+    ASSERT_EQ(static_cast<uint32_t>(13591), legacyResolver(true));
+}
+
+TEST(DebuggerService, resolveDebuggerPortUsesEnvironmentFallback) {
+    ScopedEnvironmentVariable debuggerPortEnv("VALDI_DEBUGGER_PORT");
+    debuggerPortEnv.set("14000");
+
+    auto resolution = DebuggerService::resolveDebuggerPortWithDiagnostics(false, std::nullopt);
+
+    ASSERT_EQ(static_cast<uint32_t>(14000), resolution.port);
+    ASSERT_FALSE(resolution.rejectedRequestedPort.has_value());
+    ASSERT_FALSE(resolution.environmentError.has_value());
+}
+
+TEST(DebuggerService, resolveDebuggerPortPrefersValidRequestedPort) {
+    ScopedEnvironmentVariable debuggerPortEnv("VALDI_DEBUGGER_PORT");
+    debuggerPortEnv.set("not-a-port");
+
+    auto requestedResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(false, 13702);
+    auto minimumResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(false, 1);
+    auto maximumResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(true, 65535);
+
+    ASSERT_EQ(static_cast<uint32_t>(13702), requestedResolution.port);
+    ASSERT_FALSE(requestedResolution.rejectedRequestedPort.has_value());
+    ASSERT_FALSE(requestedResolution.environmentError.has_value());
+    ASSERT_EQ(static_cast<uint32_t>(1), minimumResolution.port);
+    ASSERT_EQ(static_cast<uint32_t>(65535), maximumResolution.port);
+}
+
+TEST(DebuggerService, resolveDebuggerPortReportsInvalidRequestedPortBeforeEnvironmentFallback) {
+    ScopedEnvironmentVariable debuggerPortEnv("VALDI_DEBUGGER_PORT");
+    debuggerPortEnv.set("14000");
+
+    auto zeroResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(false, 0);
+    auto outOfRangeResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(true, 65536);
+
+    ASSERT_EQ(static_cast<uint32_t>(14000), zeroResolution.port);
+    ASSERT_EQ(std::optional<uint32_t>(0), zeroResolution.rejectedRequestedPort);
+    ASSERT_FALSE(zeroResolution.environmentError.has_value());
+    ASSERT_EQ(static_cast<uint32_t>(14000), outOfRangeResolution.port);
+    ASSERT_EQ(std::optional<uint32_t>(65536), outOfRangeResolution.rejectedRequestedPort);
+    ASSERT_FALSE(outOfRangeResolution.environmentError.has_value());
+}
+
+TEST(DebuggerService, resolveDebuggerPortReportsAllInvalidSourcesBeforePlatformFallback) {
+    ScopedEnvironmentVariable debuggerPortEnv("VALDI_DEBUGGER_PORT");
+    debuggerPortEnv.set("not-a-port");
+
+    auto resolution = DebuggerService::resolveDebuggerPortWithDiagnostics(false, 0);
+
+    ASSERT_EQ(static_cast<uint32_t>(13592), resolution.port);
+    ASSERT_EQ(std::optional<uint32_t>(0), resolution.rejectedRequestedPort);
+    ASSERT_EQ(std::optional<DebuggerPortEnvironmentError>(DebuggerPortEnvironmentError::Malformed),
+              resolution.environmentError);
+}
+
+TEST(DebuggerService, resolveDebuggerPortRejectsInvalidEnvironmentValues) {
+    ScopedEnvironmentVariable debuggerPortEnv("VALDI_DEBUGGER_PORT");
+    struct InvalidEnvironmentPort {
+        const char* value;
+        DebuggerPortEnvironmentError expectedError;
+    };
+    const std::vector<InvalidEnvironmentPort> invalidPorts = {
+        {"", DebuggerPortEnvironmentError::Malformed},
+        {"-1", DebuggerPortEnvironmentError::Malformed},
+        {"13702junk", DebuggerPortEnvironmentError::Malformed},
+        {" 13702", DebuggerPortEnvironmentError::Malformed},
+        {"13702 ", DebuggerPortEnvironmentError::Malformed},
+        {"0", DebuggerPortEnvironmentError::OutOfRange},
+        {"65536", DebuggerPortEnvironmentError::OutOfRange},
+        {"4294967296", DebuggerPortEnvironmentError::OutOfRange},
+    };
+
+    for (const auto& invalidPort : invalidPorts) {
+        debuggerPortEnv.set(invalidPort.value);
+        auto mobileResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(false, std::nullopt);
+        auto standaloneResolution = DebuggerService::resolveDebuggerPortWithDiagnostics(true, std::nullopt);
+
+        ASSERT_EQ(static_cast<uint32_t>(13592), mobileResolution.port) << invalidPort.value;
+        ASSERT_FALSE(mobileResolution.rejectedRequestedPort.has_value()) << invalidPort.value;
+        ASSERT_EQ(std::optional<DebuggerPortEnvironmentError>(invalidPort.expectedError),
+                  mobileResolution.environmentError)
+            << invalidPort.value;
+        ASSERT_EQ(static_cast<uint32_t>(13591), standaloneResolution.port) << invalidPort.value;
+        ASSERT_EQ(std::optional<DebuggerPortEnvironmentError>(invalidPort.expectedError),
+                  standaloneResolution.environmentError)
+            << invalidPort.value;
+    }
 }
 
 TEST(DebuggerService, canReceiveUpdatedResources) {

--- a/valdi/test/runtime/RuntimeManager_tests.cpp
+++ b/valdi/test/runtime/RuntimeManager_tests.cpp
@@ -1,0 +1,85 @@
+//
+//  RuntimeManager_tests.cpp
+//  valdi-pc
+//
+
+#include "valdi/runtime/Debugger/DebuggerService.hpp"
+#include "valdi/runtime/RuntimeManager.hpp"
+#include "valdi/standalone_runtime/InMemoryDiskCache.hpp"
+#include "valdi/standalone_runtime/InMemoryKeychain.hpp"
+#include "valdi_core/cpp/Utils/ConsoleLogger.hpp"
+#include "valdi_core/cpp/Utils/LoggerUtils.hpp"
+#include "valdi_test_utils.hpp"
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace Valdi;
+
+namespace ValdiTest {
+
+#if SC_LOGGING_COMPILED_IN()
+class CapturingLogger : public ILogger {
+public:
+    void log(LogType type, std::string message) override {
+        entries.emplace_back(type, std::move(message));
+    }
+
+    std::vector<std::pair<LogType, std::string>> entries;
+};
+#endif
+
+TEST(RuntimeManager, legacyConstructorRemainsCallable) {
+    auto mainQueue = makeShared<MainQueue>();
+    auto runtimeManager = makeShared<Valdi::RuntimeManager>(
+        mainQueue->createMainThreadDispatcher(),
+        nullptr,
+        makeShared<InMemoryDiskCache>(),
+        makeShared<InMemoryKeychain>(),
+        nullptr,
+        PlatformTypeLinux,
+        ThreadQoSClassNormal,
+        strongSmallRef(&ConsoleLogger::getLogger()),
+        /* enableDebuggerService */ false,
+        /* disableHotReloader */ false,
+        /* isStandalone */ true);
+
+    ASSERT_FALSE(runtimeManager->debuggerServiceEnabled());
+}
+
+#if SC_LOGGING_COMPILED_IN()
+TEST(RuntimeManager, invalidExplicitDebuggerPortWarningIsValueRedacted) {
+    if (!kDebuggerServiceEnabled) {
+        GTEST_SKIP() << "Debugger service is compile-time disabled";
+    }
+
+    auto mainQueue = makeShared<MainQueue>();
+    auto logger = makeShared<CapturingLogger>();
+    auto runtimeManager = makeShared<Valdi::RuntimeManager>(
+        mainQueue->createMainThreadDispatcher(),
+        nullptr,
+        makeShared<InMemoryDiskCache>(),
+        makeShared<InMemoryKeychain>(),
+        nullptr,
+        PlatformTypeLinux,
+        ThreadQoSClassNormal,
+        logger,
+        /* enableDebuggerService */ true,
+        /* disableHotReloader */ false,
+        /* isStandalone */ true,
+        /* debuggerPort */ 65536);
+
+    ASSERT_TRUE(runtimeManager->debuggerServiceEnabled());
+    const auto warning = std::find_if(logger->entries.begin(), logger->entries.end(), [](const auto& entry) {
+        return entry.first == LogTypeWarn && entry.second.find("requestedPort") != std::string::npos;
+    });
+    ASSERT_NE(logger->entries.end(), warning);
+    EXPECT_NE(std::string::npos, warning->second.find("<redacted>"));
+    EXPECT_EQ(std::string::npos, warning->second.find("65536"));
+}
+#endif
+
+} // namespace ValdiTest

--- a/valdi_core/src/valdi_core/ios/valdi_core/SCValdiConfiguration.h
+++ b/valdi_core/src/valdi_core/ios/valdi_core/SCValdiConfiguration.h
@@ -70,6 +70,31 @@ typedef void (^SCValdiPerformHapticFeedbackBlock)(NSString* type);
 @property (assign, nonatomic) BOOL enableReferenceTracking;
 
 /**
+ * Local-development-only debugger and hot-reload settings.
+ *
+ * These values are read when SCValdiRuntimeManager initializes its underlying
+ * RuntimeManager. Configure them through -[SCValdiRuntimeManager updateConfiguration:]
+ * before first accessing APIs that initialize the runtime, such as mainRuntime.
+ * The runtime still applies its existing compile-time debugger-service gate,
+ * so setting enableDebuggerService does not broaden release-build availability.
+ * Debugger service requests are enabled by default for compatibility with direct
+ * development hosts; hosts can set enableDebuggerService to NO to opt out.
+ */
+@property (assign, nonatomic) BOOL enableDebuggerService;
+@property (assign, nonatomic) BOOL disableHotReloader;
+
+/**
+ * Optional port for the debugger / hot-reload service.
+ *
+ * Leave this as 0 to use VALDI_DEBUGGER_PORT when present, or Valdi's platform
+ * default when it is not. Valid explicit ports are in the range 1...65535.
+ *
+ * `valdi hotreload --port` currently targets simulator / localhost reloads.
+ * Physical-device USB auto-connectors still use Valdi's default mobile port.
+ */
+@property (assign, nonatomic) NSInteger debuggerServicePort;
+
+/**
  * The currently selected JavaScript engine type.
  * In production, iOS uses the JavaScriptCore engine and Android uses QuickJS.
  * In non-production builds, this is controlled by a tweak

--- a/valdi_core/src/valdi_core/ios/valdi_core/SCValdiConfiguration.m
+++ b/valdi_core/src/valdi_core/ios/valdi_core/SCValdiConfiguration.m
@@ -9,4 +9,13 @@
 
 @implementation SCValdiConfiguration
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.enableDebuggerService = YES;
+    }
+    return self;
+}
+
 @end

--- a/valdi_core/src/valdi_core/ios/valdi_core/SCValdiRuntimeManagerProtocol.h
+++ b/valdi_core/src/valdi_core/ios/valdi_core/SCValdiRuntimeManagerProtocol.h
@@ -33,6 +33,8 @@ typedef void (^SCValdiRuntimeCreatedCallback)(id<SCValdiRuntimeProtocol>);
 /**
  The block will be provided with a SCValdiConfiguration instance that you can mutate
  and the runtime manager will apply this configuration after the block finishes executing.
+ Constructor-time settings such as debugger service configuration should be provided before
+ the underlying RuntimeManager is initialized.
  */
 - (void)updateConfiguration:(void (^)(SCValdiConfiguration* configuration))updateBlock;
 


### PR DESCRIPTION
## Description

Adds validated explicit debugger-port selection through runtime and platform bootstrap APIs while preserving the existing entry points and platform defaults.

- Preserves legacy constructor and resolver contracts while adding explicit configuration.
- Handles Android and iOS bootstrap values without logging supplied values.
- Adds focused native registration, validation, and logging coverage.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation improvement
- [ ] Performance optimization
- [x] Test improvement
- [x] Other (new debugger capability)

## Testing
- [ ] Tests pass locally (`bazel test //...`)
- [x] Added/updated tests for changes (if applicable)
- [ ] Tested on multiple platforms (iOS/Android/Web/macOS as applicable)
- [ ] Manual testing performed (describe below)

### Testing Details
- Incremental branch: Native registration and logging harnesses passed; focused TypeScript, formatting, and diff checks passed.
- Assembled debugger stack: `npm test` passed 436/436; the CLI production build passed.
- Focused `//src/valdi_modules/src/valdi/web_renderer:test` passed.
- `bazel query //...` passed.
- The broad Valdi suite reproduced the established 12 unrelated failures; all new debugger specs passed.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in description)
- [x] Commit messages follow [conventional format](../CONTRIBUTING.md#commit-messages)
- [x] No secrets, API keys, or internal URLs included

## Related Issues
Relates to #154

## Additional Context
Stack 2/22. Stacked on #154 (`bjd/upstream-debugger-foundation`). Review this PR as the single incremental commit `10af426a` against that base; do not merge it before its parent.