### PR TITLE
Add the web preview performance panel

### DIFF
--- a/docs/docs/performance-tracing.md
+++ b/docs/docs/performance-tracing.md
@@ -28,6 +28,32 @@ The debugger proxies these operations through `/api/performance/trace/status`,
 `start`, `stop`, and `capture`; the application keeps ownership of the recorder,
 so captures continue to work across the loopback debugger HTTP connection.
 
+#### Web preview traces
+
+When `valdi debugger` is attached to an exact loopback web preview, the
+integrated DevTools **Performance** panel can sample navigation, resource, heap,
+and main-thread metrics. It can also record one global Chromium trace at a
+time. The timeline filters are **Valdi**, **Browser**, and **All**. Enabling
+Valdi renderer events reloads the inspected page with the explicit tracing
+query parameters; browser events remain available without that reload.
+
+Web capture operations use the separate
+`/api/devtools/performance/trace/status`, `start`, `stop`, `capture`, and
+`enable` routes. They do not replace the daemon-backed `/api/performance/*`
+routes described above. Every web request is bound to the exact inspected
+`sessionId`, `inspectedUrl`, and per-tab `targetNonce`; a changed or incomplete
+identity fails closed.
+
+One-shot web captures run for their requested duration from 100 milliseconds
+through 15 seconds. Manually started recordings automatically stop after a
+15-second watchdog. Normalization happens as CDP events arrive, retaining at
+most 10,000 events with trace names no larger than
+2 KiB. The complete JSON response is limited to 4 MiB, and an automatically
+completed result remains retrievable for one minute. Responses contain the
+bounded normalized trace list and export metadata, not a second raw or
+Perfetto event list. The panel constructs Chrome Trace JSON only when you
+choose **Export trace**.
+
 > [!NOTE]
 > Please make sure to add `//src/valdi_modules/src/valdi/benchmarking` to the `deps` attribute of the `valdi_module()` call in your module's `BUILD.bazel`.
 

--- a/npm_modules/cli/debugger/README.md
+++ b/npm_modules/cli/debugger/README.md
@@ -21,7 +21,7 @@ the CLI package.
 - `debugger-actions.js`: UI actions, command prompt handling, auto-refresh, and externally driven debugger actions.
 - `debugger-session.js`: `sessionStorage` restore/persist for reload-friendly debugger state.
 - `debugger-bootstrap.js`: DOM event wiring and boot sequence.
-- `devtools-panel.html`, `devtools-panel.css`, and `devtools-panel.js`: the focused Chromium Elements and Console panel embedded by the generated extension.
+- `devtools-panel.html`, `devtools-panel.css`, and `devtools-panel.js`: the focused Chromium Elements, Console, and bounded Performance panel embedded by the generated extension.
 
 Scripts are loaded as classic browser scripts in the order listed in
 `index.html`. There is no module loader or bundler for this frontend; shared
@@ -71,7 +71,9 @@ requested duration from 100 milliseconds through 15 seconds; manually started
 recordings have a 15-second watchdog. An undelivered completed result is kept
 for one minute. The complete response is limited
 to 4 MiB and contains one normalized trace list plus export metadata—never a
-duplicate raw or Perfetto event list.
+duplicate raw or Perfetto event list. The panel shows at most 120 graph samples,
+120 timeline rows, and 12 grouped summary rows. Its only trace filters are
+Valdi, Browser, and All; Chrome Trace JSON is assembled only when exported.
 
 The Data section discovers target-owned providers through a generic custom
 message contract. The persistence module registers its bounded web snapshot as

--- a/npm_modules/cli/debugger/devtools-panel.css
+++ b/npm_modules/cli/debugger/devtools-panel.css
@@ -550,6 +550,408 @@ button {
   color: var(--accent);
 }
 
+.utility-section {
+  min-height: 0;
+  grid-template-rows: 32px minmax(0, 1fr);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  font-weight: 500;
+}
+
+.text-button {
+  padding: 4px 7px;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+}
+
+.utility-content {
+  min-height: 0;
+  padding: 12px;
+  overflow: auto;
+}
+
+.metric-grid {
+  display: grid;
+  margin-bottom: 15px;
+  gap: 9px;
+  grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
+}
+
+.metric-card {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+}
+
+.metric-label {
+  color: var(--muted);
+}
+
+.metric-value {
+  margin-top: 6px;
+  font-family: var(--mono);
+  font-size: 18px;
+}
+
+.metric-card-chart {
+  padding-bottom: 7px;
+}
+
+.performance-sparkline {
+  display: block;
+  width: 100%;
+  height: 30px;
+  margin-top: 7px;
+  --graph-color: var(--accent);
+}
+
+.performance-sparkline.main-thread {
+  --graph-color: var(--warning);
+}
+
+.performance-sparkline.resources {
+  --graph-color: var(--tag);
+}
+
+.performance-sparkline-baseline {
+  fill: none;
+  stroke: var(--border-soft);
+  vector-effect: non-scaling-stroke;
+}
+
+.performance-sparkline-area {
+  fill: color-mix(in srgb, var(--graph-color) 14%, transparent);
+}
+
+.performance-sparkline-line {
+  fill: none;
+  stroke: var(--graph-color);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.performance-recorder-card {
+  margin: 0 0 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--background);
+}
+
+.performance-recorder-heading,
+.performance-recorder-controls,
+.performance-legend {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.performance-recorder-heading {
+  justify-content: space-between;
+}
+
+.performance-recorder-heading > div {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+}
+
+.performance-recorder-controls {
+  flex-wrap: wrap;
+  margin: 10px 0;
+}
+
+.performance-status,
+.performance-tracing-badge {
+  padding: 2px 7px;
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.performance-status.recording {
+  background: color-mix(in srgb, var(--error) 12%, var(--background));
+  color: var(--error);
+}
+
+.performance-tracing-badge.enabled {
+  background: color-mix(in srgb, var(--success) 12%, var(--background));
+  color: var(--success);
+}
+
+.performance-tracing-badge.disabled {
+  background: color-mix(in srgb, var(--warning) 13%, var(--background));
+  color: var(--warning);
+}
+
+.performance-button {
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--surface);
+}
+
+.performance-button:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.performance-button.primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--background);
+}
+
+.performance-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.performance-duration {
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
+  gap: 4px;
+}
+
+.performance-duration input {
+  width: 55px;
+  padding: 3px 4px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--background);
+  color: var(--text);
+}
+
+.performance-notice,
+.performance-error {
+  margin: 9px 0;
+  padding: 8px;
+  border: 1px solid color-mix(in srgb, var(--warning) 45%, var(--border));
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--warning) 7%, var(--background));
+  line-height: 1.5;
+}
+
+.performance-notice .performance-button {
+  margin-left: 6px;
+}
+
+.performance-error {
+  border-color: color-mix(in srgb, var(--error) 45%, var(--border));
+  background: color-mix(in srgb, var(--error) 7%, var(--background));
+  color: var(--error);
+}
+
+.performance-caption {
+  margin: 8px 0;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.performance-trace-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  margin: 11px 0 6px;
+  gap: 8px;
+}
+
+.performance-scope-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.performance-scope-button {
+  padding: 4px 7px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 10px;
+}
+
+.performance-scope-button.selected {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, var(--background));
+  color: var(--accent);
+}
+
+.performance-scope-button span {
+  margin-left: 3px;
+  color: var(--muted);
+}
+
+.performance-trace-search {
+  min-width: 175px;
+  flex: 1 1 175px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--background);
+  color: var(--text);
+  font-size: 10px;
+}
+
+.performance-legend {
+  flex-wrap: wrap;
+  margin: 11px 0 7px;
+}
+
+.performance-legend-item {
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
+  font-size: 10px;
+  gap: 4px;
+}
+
+.performance-legend-item::before {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--lane-color);
+  content: '';
+}
+
+.performance-event-bar.valdi,
+.performance-legend-item.valdi {
+  --lane-color: var(--accent);
+}
+
+.performance-event-bar.script,
+.performance-legend-item.script {
+  --lane-color: var(--warning);
+}
+
+.performance-event-bar.layout,
+.performance-legend-item.layout {
+  --lane-color: var(--tag);
+}
+
+.performance-event-bar.paint,
+.performance-legend-item.paint {
+  --lane-color: var(--success);
+}
+
+.performance-event-bar.frames,
+.performance-legend-item.frames {
+  --lane-color: var(--attribute);
+}
+
+.performance-event-bar.gc,
+.performance-legend-item.gc {
+  --lane-color: var(--error);
+}
+
+.performance-timeline {
+  max-height: 350px;
+  overflow: auto;
+  border: 1px solid var(--border-soft);
+  border-radius: 3px;
+}
+
+.performance-timeline-row {
+  display: grid;
+  min-height: 21px;
+  align-items: center;
+  border-bottom: 1px solid var(--border-soft);
+  font-family: var(--mono);
+  font-size: 10px;
+  gap: 6px;
+  grid-template-columns: minmax(120px, 30%) minmax(80px, 1fr) 62px;
+}
+
+.performance-timeline-row:last-child {
+  border-bottom: 0;
+}
+
+.performance-event-name,
+.performance-event-duration {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.performance-event-name {
+  padding-left: 6px;
+}
+
+.performance-event-duration {
+  padding-right: 5px;
+  color: var(--muted);
+  text-align: right;
+}
+
+.performance-event-track {
+  position: relative;
+  height: 15px;
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+}
+
+.performance-event-bar {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  min-width: 2px;
+  border-radius: 2px;
+  background: var(--lane-color);
+}
+
+.utility-heading {
+  margin: 13px 0 7px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.performance-results-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.performance-results-table th,
+.performance-results-table td {
+  padding: 5px 6px;
+  border-bottom: 1px solid var(--border-soft);
+  text-align: left;
+}
+
+.performance-results-table th {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.performance-results-table th:not(:first-child),
+.performance-results-table td:not(:first-child) {
+  text-align: right;
+}
+
+.performance-navigation {
+  margin: 10px 0;
+  color: var(--muted);
+}
+
+.performance-navigation summary {
+  cursor: pointer;
+}
+
 .console-section {
   min-height: 0;
   grid-template-rows: minmax(0, 1fr) 32px;

--- a/npm_modules/cli/debugger/devtools-panel.html
+++ b/npm_modules/cli/debugger/devtools-panel.html
@@ -10,8 +10,39 @@
     <div class="devtools-app">
       <header class="main-toolbar">
         <nav class="main-tabs" aria-label="Valdi development tools" role="tablist">
-          <button class="main-tab selected" data-section="elements" role="tab" aria-selected="true">Elements</button>
-          <button class="main-tab" data-section="console" role="tab" aria-selected="false">Console</button>
+          <button
+            id="elementsTab"
+            type="button"
+            class="main-tab selected"
+            data-section="elements"
+            role="tab"
+            aria-controls="elementsSection"
+            aria-selected="true"
+          >
+            Elements
+          </button>
+          <button
+            id="performanceTab"
+            type="button"
+            class="main-tab"
+            data-section="performance"
+            role="tab"
+            aria-controls="performanceSection"
+            aria-selected="false"
+          >
+            Performance
+          </button>
+          <button
+            id="consoleTab"
+            type="button"
+            class="main-tab"
+            data-section="console"
+            role="tab"
+            aria-controls="consoleSection"
+            aria-selected="false"
+          >
+            Console
+          </button>
         </nav>
         <div class="toolbar-spacer"></div>
         <button id="refreshButton" class="icon-button" title="Refresh inspected application" aria-label="Refresh">
@@ -31,7 +62,13 @@
       </div>
 
       <main class="main-content">
-        <section id="elementsSection" class="section selected" data-panel="elements">
+        <section
+          id="elementsSection"
+          class="section selected"
+          data-panel="elements"
+          role="tabpanel"
+          aria-labelledby="elementsTab"
+        >
           <div class="tree-pane">
             <div class="filter-toolbar">
               <svg class="filter-icon" viewBox="0 0 20 20" aria-hidden="true">
@@ -77,7 +114,29 @@
           </footer>
         </section>
 
-        <section id="consoleSection" class="section console-section" data-panel="console">
+        <section
+          id="performanceSection"
+          class="section utility-section"
+          data-panel="performance"
+          role="tabpanel"
+          aria-labelledby="performanceTab"
+        >
+          <div class="section-header">
+            <span>Web preview performance</span>
+            <button type="button" class="text-button" data-performance-action="refresh">Refresh</button>
+          </div>
+          <div id="performanceContent" class="utility-content">
+            <div class="empty-state">Open Performance to inspect the selected web preview.</div>
+          </div>
+        </section>
+
+        <section
+          id="consoleSection"
+          class="section console-section"
+          data-panel="console"
+          role="tabpanel"
+          aria-labelledby="consoleTab"
+        >
           <div id="consoleMessages" class="console-messages"></div>
           <form id="consoleForm" class="console-prompt">
             <span class="console-chevron">›</span>

--- a/npm_modules/cli/debugger/devtools-panel.js
+++ b/npm_modules/cli/debugger/devtools-panel.js
@@ -4,6 +4,9 @@ const inspectedTargetNonce = query.get('targetNonce');
 const MAX_CONSOLE_ENTRIES = 500;
 const MAX_CONSOLE_ENTRY_CHARACTERS = 50_000;
 const MAX_CONSOLE_HISTORY_ENTRIES = 100;
+const MAX_PERFORMANCE_SAMPLES = 120;
+const MAX_PERFORMANCE_TIMELINE_ROWS = 120;
+const MAX_PERFORMANCE_SUMMARY_ROWS = 12;
 
 const state = {
   target: null,
@@ -31,6 +34,23 @@ const state = {
   consoleHistoryIndex: 0,
   consoleStream: null,
   consoleStreamTargetKey: null,
+  performance: {
+    data: null,
+    durationSeconds: 3,
+    error: null,
+    lastTrace: null,
+    navigationExpanded: false,
+    operationGeneration: 0,
+    ownerIdentity: null,
+    pending: false,
+    rendererTracingEnabled: false,
+    requestGeneration: 0,
+    samples: [],
+    snapshotPending: false,
+    traceActive: false,
+    traceScope: 'valdi',
+    traceSearch: '',
+  },
   error: null,
 };
 
@@ -57,6 +77,7 @@ const elements = {
   consoleMessages: document.getElementById('consoleMessages'),
   consoleForm: document.getElementById('consoleForm'),
   consoleInput: document.getElementById('consoleInput'),
+  performanceContent: document.getElementById('performanceContent'),
 };
 
 function escapeHtml(value) {
@@ -97,12 +118,98 @@ async function requestJson(path, params, options) {
   return payload;
 }
 
+function stopPerformanceOnPageHide() {
+  const identity = state.performance.ownerIdentity;
+  if (!identity) return;
+  const url = new URL('/api/devtools/performance/trace/stop', window.location.origin);
+  for (const [key, value] of Object.entries(identity)) url.searchParams.set(key, String(value));
+  void fetch(url, {
+    body: '{}',
+    headers: { 'Content-Type': 'application/json' },
+    keepalive: true,
+    method: 'POST',
+  }).catch(error => console.warn('Unable to stop the web preview performance trace while closing DevTools.', error));
+}
+
 function formatNumber(value) {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return '—';
   return Number.isInteger(numeric)
     ? numeric.toLocaleString()
     : numeric.toLocaleString(undefined, { maximumFractionDigits: 1 });
+}
+
+function formatBytes(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return '—';
+  if (numeric < 1024) return `${formatNumber(numeric)} B`;
+  if (numeric < 1024 * 1024) return `${formatNumber(numeric / 1024)} KiB`;
+  return `${formatNumber(numeric / (1024 * 1024))} MiB`;
+}
+
+function formatDuration(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return '—';
+  if (numeric < 1) return `${formatNumber(numeric * 1000)} µs`;
+  if (numeric < 1000) return `${formatNumber(numeric)} ms`;
+  return `${formatNumber(numeric / 1000)} s`;
+}
+
+function formatUptime(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return '—';
+  if (numeric < 60_000) return `${formatNumber(numeric / 1000)} s`;
+  return `${formatNumber(numeric / 60_000)} min`;
+}
+
+function performanceIdentity(target = state.target) {
+  if (!target?.sessionId || !inspectedUrl || !inspectedTargetNonce) {
+    throw new Error('The selected web preview does not have a complete performance identity.');
+  }
+  return {
+    inspectedUrl,
+    sessionId: target.sessionId,
+    targetNonce: inspectedTargetNonce,
+  };
+}
+
+function samePerformanceIdentity(left, right) {
+  return Boolean(
+    left &&
+      right &&
+      left.sessionId === right.sessionId &&
+      left.inspectedUrl === right.inspectedUrl &&
+      left.targetNonce === right.targetNonce,
+  );
+}
+
+function performanceIdentityIsCurrent(identity) {
+  try {
+    return samePerformanceIdentity(identity, performanceIdentity());
+  } catch {
+    return false;
+  }
+}
+
+function performancePollingInputIsFocused() {
+  return ['performanceDurationInput', 'performanceTraceFilter'].includes(document.activeElement?.id);
+}
+
+function preparePerformanceForTargetChange() {
+  const perf = state.performance;
+  perf.requestGeneration++;
+  perf.operationGeneration++;
+  perf.snapshotPending = false;
+  perf.pending = false;
+  perf.data = null;
+  perf.lastTrace = null;
+  perf.rendererTracingEnabled = false;
+  perf.samples = [];
+  if (perf.traceActive || perf.ownerIdentity) {
+    perf.error = 'The previous web preview still owns a performance recording. Stop and retrieve it before switching.';
+    return;
+  }
+  perf.error = null;
 }
 
 function nodeAttributes(node) {
@@ -236,6 +343,7 @@ async function connectToInspectedApplication() {
       state.consoleEntries = [];
       state.consoleEntryKeys.clear();
       elements.consoleMessages.innerHTML = '';
+      preparePerformanceForTargetChange();
     }
     state.target = payload.target;
     elements.targetName.textContent = state.target.name || 'Valdi application';
@@ -304,8 +412,9 @@ async function refreshSnapshot() {
 function startRefreshTimer() {
   if (state.refreshTimer) window.clearInterval(state.refreshTimer);
   state.refreshTimer = window.setInterval(() => {
-    if (!state.autoRefresh || document.hidden || state.activeSection !== 'elements') return;
-    void refreshSnapshot();
+    if (!state.autoRefresh || document.hidden) return;
+    if (state.activeSection === 'elements') void refreshSnapshot();
+    if (state.activeSection === 'performance') void refreshPerformance({ silent: true });
   }, 1200);
 }
 
@@ -649,6 +758,528 @@ function queueHighlight(nodeIdValue) {
   );
 }
 
+function renderPerformanceMetric(label, value) {
+  return `<div class="metric-card"><div class="metric-label">${escapeHtml(label)}</div><div class="metric-value">${escapeHtml(value)}</div></div>`;
+}
+
+function recordPerformanceSample(data) {
+  const uptimeMs = Number(data?.uptimeMs);
+  if (!Number.isFinite(uptimeMs) || uptimeMs < 0) return;
+  const samples = state.performance.samples;
+  const previous = samples[samples.length - 1];
+  if (previous?.uptimeMs === uptimeMs) return;
+  if (previous && previous.uptimeMs > uptimeMs) samples.length = 0;
+  const sample = { uptimeMs };
+  for (const [property, value] of [
+    ['heapUsedBytes', data?.memory?.usedBytes],
+    ['layoutDurationMs', data?.mainThread?.layoutDurationMs],
+    ['resourceCount', data?.resourceCount],
+    ['scriptDurationMs', data?.mainThread?.scriptDurationMs],
+    ['taskDurationMs', data?.mainThread?.taskDurationMs],
+  ]) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric >= 0) sample[property] = numeric;
+  }
+  samples.push(sample);
+  if (samples.length > MAX_PERFORMANCE_SAMPLES) {
+    samples.splice(0, samples.length - MAX_PERFORMANCE_SAMPLES);
+  }
+}
+
+function performanceGraphPath(points, minimum, maximum) {
+  if (!points.length) return '';
+  const firstTime = points[0].time;
+  const lastTime = points[points.length - 1].time;
+  const timeSpan = Math.max(lastTime - firstTime, 1);
+  const valueSpan = Math.max(maximum - minimum, 1);
+  return points
+    .map((point, index) => {
+      const x = points.length === 1 ? 100 : ((point.time - firstTime) / timeSpan) * 100;
+      const y = 27 - Math.max(0, Math.min(1, (point.value - minimum) / valueSpan)) * 23;
+      return `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(' ');
+}
+
+function renderSampledPerformanceMetric(label, kind, property, formattedValue) {
+  const points = state.performance.samples
+    .filter(sample => Number.isFinite(sample[property]))
+    .map(sample => ({ time: sample.uptimeMs, value: sample[property] }));
+  if (!points.length) return renderPerformanceMetric(label, formattedValue);
+  const minimum = Math.min(...points.map(point => point.value));
+  const maximum = Math.max(...points.map(point => point.value));
+  const padding = Math.max((maximum - minimum) * 0.12, maximum * 0.015, 1);
+  const path = performanceGraphPath(points, Math.max(0, minimum - padding), maximum + padding);
+  return `
+    <article class="metric-card metric-card-chart">
+      <div class="metric-label">${escapeHtml(label)}</div>
+      <div class="metric-value">${escapeHtml(formattedValue)}</div>
+      <svg class="performance-sparkline ${escapeHtml(kind)}" viewBox="0 0 100 30" preserveAspectRatio="none" role="img" aria-label="${escapeHtml(label)} over time">
+        <path class="performance-sparkline-baseline" d="M0 27H100" />
+        <path class="performance-sparkline-area" d="${path} L100 27 L0 27 Z" />
+        <path class="performance-sparkline-line" d="${path}" />
+      </svg>
+    </article>
+  `;
+}
+
+function performanceScopeMatches(trace, scope) {
+  const name = String(trace?.trace || '');
+  if (scope === 'valdi') return name.startsWith('Valdi.');
+  if (scope === 'browser') return name.startsWith('Browser.');
+  return name.startsWith('Valdi.') || name.startsWith('Browser.');
+}
+
+function filteredPerformanceTraces(result) {
+  const search = String(state.performance.traceSearch || '')
+    .trim()
+    .toLowerCase();
+  const traces = Array.isArray(result?.traces) ? result.traces : [];
+  return traces.filter(
+    trace =>
+      performanceScopeMatches(trace, state.performance.traceScope) &&
+      (!search ||
+        String(trace.trace || '')
+          .toLowerCase()
+          .includes(search)),
+  );
+}
+
+function performanceScopeCounts(traces) {
+  const counts = { all: 0, browser: 0, valdi: 0 };
+  for (const trace of traces) {
+    if (!performanceScopeMatches(trace, 'all')) continue;
+    counts.all++;
+    if (performanceScopeMatches(trace, 'valdi')) counts.valdi++;
+    if (performanceScopeMatches(trace, 'browser')) counts.browser++;
+  }
+  return counts;
+}
+
+function performanceLane(trace) {
+  const name = String(trace?.trace || '');
+  if (name.startsWith('Valdi.')) return 'valdi';
+  if (name.startsWith('Browser.Layout.')) return 'layout';
+  if (name.startsWith('Browser.Paint.')) return 'paint';
+  if (name.startsWith('Browser.Frames.')) return 'frames';
+  if (name.startsWith('Browser.GC.')) return 'gc';
+  return 'script';
+}
+
+function renderPerformanceTimeline(result) {
+  const traces = Array.isArray(result?.traces) ? result.traces : [];
+  const counts = performanceScopeCounts(traces);
+  const scopes = [
+    ['valdi', 'Valdi'],
+    ['browser', 'Browser'],
+    ['all', 'All'],
+  ];
+  const controls = `
+    <div class="performance-trace-filters">
+      <div class="performance-scope-group" role="group" aria-label="Trace event scope">
+        ${scopes
+          .map(
+            ([scope, label]) =>
+              `<button type="button" class="performance-scope-button${state.performance.traceScope === scope ? ' selected' : ''}" data-performance-scope="${scope}" aria-pressed="${state.performance.traceScope === scope ? 'true' : 'false'}">${label} <span>${escapeHtml(formatNumber(counts[scope]))}</span></button>`,
+          )
+          .join('')}
+      </div>
+      <input id="performanceTraceFilter" class="performance-trace-search" type="search" value="${escapeHtml(state.performance.traceSearch)}" placeholder="Filter trace names" aria-label="Filter trace names" />
+    </div>
+  `;
+  if (!traces.length) {
+    return `${controls}<div class="empty-state">Record an interaction to inspect browser and Valdi renderer events.</div>`;
+  }
+  const filtered = filteredPerformanceTraces(result);
+  if (!filtered.length) return `${controls}<div class="empty-state">No captured events match this filter.</div>`;
+
+  let firstTimestamp = Infinity;
+  let lastTimestamp = -Infinity;
+  for (const trace of filtered) {
+    firstTimestamp = Math.min(firstTimestamp, Number(trace.startMicros));
+    lastTimestamp = Math.max(lastTimestamp, Number(trace.endMicros));
+  }
+  const spanMicros = Math.max(lastTimestamp - firstTimestamp, 1000);
+  const displayed = filtered.slice(0, MAX_PERFORMANCE_TIMELINE_ROWS);
+  const rows = displayed
+    .map(trace => {
+      const startMicros = Number(trace.startMicros);
+      const durationMicros = Math.max(0, Number(trace.endMicros) - startMicros);
+      const offset = Math.max(0, Math.min(100, ((startMicros - firstTimestamp) / spanMicros) * 100));
+      const width = Math.max(0.65, Math.min(100 - offset, (durationMicros / spanMicros) * 100));
+      const duration = trace.type === 1 ? 'instant' : formatDuration(durationMicros / 1000);
+      const name = String(trace.trace || '').replace(/^Browser\./, '');
+      return `
+        <div class="performance-timeline-row" title="${escapeHtml(trace.trace)}">
+          <span class="performance-event-name">${escapeHtml(name)}</span>
+          <span class="performance-event-track"><span class="performance-event-bar ${performanceLane(trace)}" style="left:${offset.toFixed(3)}%;width:${width.toFixed(3)}%"></span></span>
+          <span class="performance-event-duration">${escapeHtml(duration)}</span>
+        </div>
+      `;
+    })
+    .join('');
+  const truncated =
+    filtered.length > displayed.length
+      ? `<div class="performance-caption">Showing ${formatNumber(displayed.length)} of ${formatNumber(filtered.length)} matching events. Export includes every bounded event.</div>`
+      : '';
+  return `
+    ${controls}
+    <div class="performance-legend">
+      <span class="performance-legend-item valdi">Valdi</span>
+      <span class="performance-legend-item script">JavaScript</span>
+      <span class="performance-legend-item layout">Layout</span>
+      <span class="performance-legend-item paint">Paint</span>
+      <span class="performance-legend-item frames">Frames</span>
+      <span class="performance-legend-item gc">GC</span>
+    </div>
+    <div class="performance-timeline">${rows}</div>
+    ${truncated}
+  `;
+}
+
+function renderPerformanceSummary(result) {
+  const grouped = new Map();
+  for (const trace of filteredPerformanceTraces(result)) {
+    const name = String(trace.trace || '');
+    const event = grouped.get(name) || { count: 0, durationMs: 0, name };
+    event.count++;
+    event.durationMs += Math.max(0, Number(trace.endMicros) - Number(trace.startMicros)) / 1000;
+    grouped.set(name, event);
+  }
+  const rows = Array.from(grouped.values())
+    .sort((left, right) => right.durationMs - left.durationMs || right.count - left.count)
+    .slice(0, MAX_PERFORMANCE_SUMMARY_ROWS)
+    .map(
+      event =>
+        `<tr><td>${escapeHtml(event.name)}</td><td>${escapeHtml(formatNumber(event.count))}</td><td>${escapeHtml(formatDuration(event.durationMs))}</td></tr>`,
+    )
+    .join('');
+  if (!rows) return '';
+  return `
+    <div class="utility-heading">Total captured duration by event</div>
+    <table class="performance-results-table"><thead><tr><th>Operation</th><th>Calls</th><th>Inclusive total</th></tr></thead><tbody>${rows}</tbody></table>
+  `;
+}
+
+function performanceButton(label, action, options = {}) {
+  return `<button type="button" class="performance-button${options.primary ? ' primary' : ''}" data-performance-action="${escapeHtml(action)}"${options.disabled ? ' disabled' : ''}>${escapeHtml(label)}</button>`;
+}
+
+function replacePerformanceContent(html) {
+  const contentScrollTop = elements.performanceContent.scrollTop;
+  const previousTimeline = elements.performanceContent.querySelector?.('.performance-timeline');
+  const timelineScrollLeft = previousTimeline?.scrollLeft ?? 0;
+  const timelineScrollTop = previousTimeline?.scrollTop ?? 0;
+  elements.performanceContent.innerHTML = html;
+  elements.performanceContent.scrollTop = contentScrollTop;
+  const nextTimeline = elements.performanceContent.querySelector?.('.performance-timeline');
+  if (nextTimeline) {
+    nextTimeline.scrollLeft = timelineScrollLeft;
+    nextTimeline.scrollTop = timelineScrollTop;
+  }
+}
+
+function renderPerformance(data = state.performance.data) {
+  const perf = state.performance;
+  if (!data) {
+    const error = perf.error ? `<div class="performance-error" role="alert">${escapeHtml(perf.error)}</div>` : '';
+    const ownerRecovery = perf.ownerIdentity
+      ? `<section class="performance-recorder-card"><div class="performance-recorder-heading"><strong>Previous web preview recording</strong><span class="performance-status recording" role="status" aria-live="polite">${perf.traceActive ? 'Recording' : 'Result pending'}</span></div><div class="performance-recorder-controls">${performanceButton('Stop and retrieve', 'trace-stop', { disabled: perf.pending, primary: true })}</div></section>`
+      : '';
+    replacePerformanceContent(
+      error || ownerRecovery
+        ? `${error}${ownerRecovery}`
+        : '<div class="empty-state">Loading web preview performance…</div>',
+    );
+    return;
+  }
+  perf.data = data;
+  recordPerformanceSample(data);
+  const browserMetrics = perf.lastTrace?.browserMetrics || {};
+  const browserSummary = perf.lastTrace?.browserSummary || {};
+  const metrics = [
+    renderSampledPerformanceMetric('JS heap', 'heap', 'heapUsedBytes', formatBytes(data.memory?.usedBytes)),
+    renderSampledPerformanceMetric(
+      'Main-thread time (page lifetime)',
+      'main-thread',
+      'taskDurationMs',
+      formatDuration(data.mainThread?.taskDurationMs),
+    ),
+    renderSampledPerformanceMetric(
+      'JavaScript time (page lifetime)',
+      'script',
+      'scriptDurationMs',
+      formatDuration(data.mainThread?.scriptDurationMs),
+    ),
+    renderSampledPerformanceMetric(
+      'Layout time (page lifetime)',
+      'layout',
+      'layoutDurationMs',
+      formatDuration(data.mainThread?.layoutDurationMs),
+    ),
+    renderSampledPerformanceMetric('Resources', 'resources', 'resourceCount', formatNumber(data.resourceCount)),
+    renderPerformanceMetric('Page uptime', formatUptime(data.uptimeMs)),
+  ];
+  if (perf.lastTrace) {
+    metrics.push(
+      renderPerformanceMetric('Captured events', formatNumber(perf.lastTrace.traceCount)),
+      renderPerformanceMetric('Long tasks', formatNumber(browserSummary.longTaskCount)),
+      renderPerformanceMetric('Layout passes', formatNumber(browserMetrics.LayoutCount)),
+    );
+  }
+  const hasTraceOwner = Boolean(perf.traceActive || perf.ownerIdentity);
+  const rendererStatus = perf.rendererTracingEnabled
+    ? '<span class="performance-tracing-badge enabled">Valdi renderer events enabled</span>'
+    : '<span class="performance-tracing-badge disabled">Valdi renderer events disabled</span>';
+  const rendererNotice = perf.rendererTracingEnabled
+    ? ''
+    : `<div class="performance-notice">Browser events can be recorded now. Valdi renderer events require reloading the inspected page; reloading can reset page state. ${performanceButton('Enable renderer events', 'enable-tracing', { disabled: perf.pending || hasTraceOwner })}</div>`;
+  const traceStatus = `<span class="performance-status${hasTraceOwner ? ' recording' : ''}" role="status" aria-live="polite">${perf.traceActive ? 'Recording' : perf.ownerIdentity ? 'Result pending' : 'Idle'}</span>`;
+  const traceCaption = perf.lastTrace
+    ? `<div class="performance-caption">${escapeHtml(formatNumber(perf.lastTrace.traceCount))} events · ${escapeHtml(formatDuration(perf.lastTrace.elapsedMs))}${perf.lastTrace.droppedTraceEventCount ? ` · ${escapeHtml(formatNumber(perf.lastTrace.droppedTraceEventCount))} dropped` : ''}</div>`
+    : '';
+  const paints = (Array.isArray(data.paints) ? data.paints : [])
+    .map(paint => `<tr><td>${escapeHtml(paint.name)}</td><td>${escapeHtml(formatDuration(paint.startTime))}</td></tr>`)
+    .join('');
+  replacePerformanceContent(`
+    <div class="metric-grid">${metrics.join('')}</div>
+    <div class="performance-caption">Main-thread, JavaScript, and layout counters are cumulative for the current page lifetime.</div>
+    ${perf.error ? `<div class="performance-error" role="alert">${escapeHtml(perf.error)}</div>` : ''}
+    <section class="performance-recorder-card">
+      <div class="performance-recorder-heading"><div><strong>Rendering and main-thread trace</strong>${rendererStatus}</div>${traceStatus}</div>
+      <div class="performance-recorder-controls">
+        <label class="performance-duration">Duration <input id="performanceDurationInput" type="number" min="0.1" max="15" step="0.5" value="${escapeHtml(perf.durationSeconds)}" /> s</label>
+        ${performanceButton('Start', 'trace-start', { disabled: perf.pending || hasTraceOwner })}
+        ${performanceButton('Stop', 'trace-stop', { disabled: perf.pending || !hasTraceOwner, primary: hasTraceOwner })}
+        ${performanceButton('Capture', 'trace-capture', { disabled: perf.pending || hasTraceOwner, primary: !hasTraceOwner })}
+        ${performanceButton('Export trace', 'trace-export', { disabled: !perf.lastTrace })}
+      </div>
+      ${rendererNotice}
+      ${traceCaption}
+      ${renderPerformanceTimeline(perf.lastTrace)}
+      ${renderPerformanceSummary(perf.lastTrace)}
+    </section>
+    <details class="performance-navigation"${perf.navigationExpanded ? ' open' : ''}>
+      <summary>Initial page-load milestones</summary>
+      <div class="performance-caption">DOM ready ${escapeHtml(formatDuration(data.navigation?.domContentLoadedMs))} · Page load ${escapeHtml(formatDuration(data.navigation?.loadMs))} · Transferred ${escapeHtml(formatBytes(data.transferSize))}</div>
+      ${paints ? `<table class="performance-results-table"><tbody>${paints}</tbody></table>` : '<div class="empty-state">No paint milestones have been reported.</div>'}
+    </details>
+  `);
+}
+
+function buildPerformanceTraceExport(result) {
+  const traces = Array.isArray(result?.traces) ? result.traces : [];
+  const firstTimestamp = traces.reduce(
+    (minimum, trace) => Math.min(minimum, Number(trace.startMicros)),
+    Number(traces[0]?.startMicros || 0),
+  );
+  const threadIds = Array.from(new Set(traces.map(trace => Number(trace.threadId)))).slice(0, 256);
+  const traceEvents = [
+    { args: { name: 'Valdi web preview' }, name: 'process_name', ph: 'M', pid: 1 },
+    ...threadIds.map(threadId => ({
+      args: { name: `Thread ${threadId}` },
+      name: 'thread_name',
+      ph: 'M',
+      pid: 1,
+      tid: threadId,
+    })),
+  ];
+  for (const trace of traces) {
+    const instant = trace.type === 1;
+    const event = {
+      cat: String(trace.trace || '').startsWith('Valdi.') ? 'valdi' : 'browser',
+      name: String(trace.trace || ''),
+      ph: instant ? 'i' : 'X',
+      pid: 1,
+      tid: Number(trace.threadId),
+      ts: Number(trace.startMicros) - firstTimestamp,
+    };
+    if (instant) event.s = 't';
+    else event.dur = Math.max(0, Number(trace.endMicros) - Number(trace.startMicros));
+    traceEvents.push(event);
+  }
+  return {
+    displayTimeUnit: 'ms',
+    metadata: result?.perfettoMetadata || {},
+    traceEvents,
+  };
+}
+
+function downloadPerformanceTrace(result) {
+  const blob = new Blob([JSON.stringify(buildPerformanceTraceExport(result), null, 2)], {
+    type: 'application/json',
+  });
+  const artifactUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = artifactUrl;
+  link.download = `valdi-web-preview-${Date.now()}.trace.json`;
+  link.click();
+  window.setTimeout(() => URL.revokeObjectURL(artifactUrl), 1000);
+}
+
+async function refreshPerformance(options = {}) {
+  if (options.silent && performancePollingInputIsFocused()) return;
+  if (!state.target || state.performance.pending || state.performance.snapshotPending) return;
+  const perf = state.performance;
+  const identity = performanceIdentity();
+  const requestGeneration = ++perf.requestGeneration;
+  const requestIsCurrent = () => requestGeneration === perf.requestGeneration && performanceIdentityIsCurrent(identity);
+  perf.snapshotPending = true;
+  if (!options.silent && !perf.data) renderPerformance();
+  try {
+    const [data, status] = await Promise.all([
+      requestJson('/api/devtools/performance/snapshot', identity, {}),
+      requestJson('/api/devtools/performance/trace/status', identity, {}),
+    ]);
+    if (status.completionError) {
+      try {
+        await requestJson('/api/devtools/performance/trace/stop', identity, { body: {} });
+      } catch {
+        // Stop surfaces the retained completion error after clearing it on the server.
+      }
+      if (requestIsCurrent() && (!perf.ownerIdentity || samePerformanceIdentity(perf.ownerIdentity, identity))) {
+        perf.traceActive = false;
+        perf.ownerIdentity = null;
+      }
+      throw new Error(status.completionError);
+    }
+    let completedTrace = null;
+    if (status.completedRecordingAvailable) {
+      completedTrace = await requestJson('/api/devtools/performance/trace/stop', identity, { body: {} });
+    }
+    if (!requestIsCurrent()) return;
+    perf.data = data;
+    if (!perf.ownerIdentity || samePerformanceIdentity(perf.ownerIdentity, identity)) {
+      perf.traceActive = Boolean(status.recording);
+      perf.ownerIdentity = perf.traceActive ? identity : null;
+    }
+    perf.rendererTracingEnabled = Boolean(data.rendererTracingEnabled || status.rendererTracingEnabled);
+    if (completedTrace) {
+      perf.traceActive = false;
+      perf.ownerIdentity = null;
+      perf.lastTrace = completedTrace;
+    }
+    perf.error = null;
+    renderPerformance(data);
+  } catch (error) {
+    if (requestIsCurrent()) {
+      perf.error = error instanceof Error ? error.message : String(error);
+      renderPerformance(perf.data);
+    }
+  } finally {
+    if (requestIsCurrent()) perf.snapshotPending = false;
+  }
+}
+
+async function runPerformanceAction(action) {
+  const perf = state.performance;
+  if (action === 'refresh') {
+    await refreshPerformance();
+    return;
+  }
+  if (action === 'trace-export') {
+    if (perf.lastTrace) downloadPerformanceTrace(perf.lastTrace);
+    return;
+  }
+  if (!state.target || perf.pending) return;
+  if (['enable-tracing', 'trace-capture', 'trace-start'].includes(action) && (perf.traceActive || perf.ownerIdentity)) {
+    return;
+  }
+  if (
+    action === 'enable-tracing' &&
+    !window.confirm('Enable Valdi renderer events? This reloads the inspected page and can reset page state.')
+  ) {
+    return;
+  }
+
+  const selectedIdentity = performanceIdentity();
+  const identity = action === 'trace-stop' && perf.ownerIdentity ? perf.ownerIdentity : selectedIdentity;
+  perf.requestGeneration++;
+  perf.snapshotPending = false;
+  const operationGeneration = ++perf.operationGeneration;
+  const selectedTargetIsCurrent = () =>
+    operationGeneration === perf.operationGeneration && performanceIdentityIsCurrent(selectedIdentity);
+  const operationOwnsTrace = () => samePerformanceIdentity(perf.ownerIdentity, identity);
+  let refreshSelectedTarget = false;
+  perf.pending = true;
+  perf.error = null;
+  renderPerformance(perf.data);
+  try {
+    if (action === 'enable-tracing') {
+      await requestJson('/api/devtools/performance/trace/enable', identity, { body: {} });
+      if (!selectedTargetIsCurrent()) return;
+      perf.rendererTracingEnabled = true;
+      addConsoleEntry('info', 'Reloaded the inspected page with Valdi renderer events enabled.');
+    } else {
+      const operation = action.slice('trace-'.length);
+      const durationMs = Math.round(Math.max(0.1, Math.min(15, Number(perf.durationSeconds) || 3)) * 1000);
+      if (operation === 'capture') {
+        perf.traceActive = true;
+        perf.ownerIdentity = identity;
+        renderPerformance(perf.data);
+      }
+      const result = await requestJson(`/api/devtools/performance/trace/${operation}`, identity, {
+        body: operation === 'capture' ? { durationMs } : {},
+      });
+      if (operation === 'start') {
+        if (!selectedTargetIsCurrent()) {
+          if (result.recording) {
+            try {
+              await requestJson('/api/devtools/performance/trace/stop', identity, { body: {} });
+            } catch (cleanupError) {
+              if (!perf.ownerIdentity || samePerformanceIdentity(perf.ownerIdentity, identity)) {
+                perf.traceActive = true;
+                perf.ownerIdentity = identity;
+                perf.error = `The previous web preview still owns a performance recording: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`;
+                if (state.activeSection === 'performance') renderPerformance(perf.data);
+              }
+            }
+          }
+          return;
+        }
+        perf.traceActive = Boolean(result.recording);
+        perf.ownerIdentity = perf.traceActive ? identity : null;
+        refreshSelectedTarget = true;
+      } else {
+        const completedOwnedTrace = ['capture', 'stop'].includes(operation) && operationOwnsTrace();
+        const completedPreviousOwner = completedOwnedTrace && !samePerformanceIdentity(identity, selectedIdentity);
+        if (completedOwnedTrace) {
+          perf.traceActive = false;
+          perf.ownerIdentity = null;
+        }
+        if (completedPreviousOwner) {
+          perf.data = null;
+          perf.lastTrace = null;
+          perf.rendererTracingEnabled = false;
+          perf.samples = [];
+        }
+        if (selectedTargetIsCurrent() && !completedPreviousOwner) {
+          perf.traceActive = false;
+          perf.ownerIdentity = null;
+          perf.lastTrace = result;
+        }
+        refreshSelectedTarget = selectedTargetIsCurrent();
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (selectedTargetIsCurrent() || operationOwnsTrace()) {
+      perf.error = message;
+      if (state.activeSection === 'performance') renderPerformance(perf.data);
+    } else {
+      console.warn('Ignoring a stale web preview performance action error.', error);
+    }
+  } finally {
+    if (selectedTargetIsCurrent()) {
+      perf.pending = false;
+      if (state.activeSection === 'performance') renderPerformance(perf.data);
+    }
+  }
+  if (refreshSelectedTarget && selectedTargetIsCurrent() && state.target) {
+    await refreshPerformance({ silent: true });
+  }
+}
+
 function setActiveSection(section) {
   state.activeSection = section;
   for (const tab of elements.mainTabs) {
@@ -661,6 +1292,7 @@ function setActiveSection(section) {
   }
   if (section === 'console') elements.consoleInput.focus();
   if (section === 'elements') void refreshSnapshot();
+  if (section === 'performance') void refreshPerformance();
 }
 
 function setActiveDetail(detail) {
@@ -823,7 +1455,46 @@ function wireEvents() {
   for (const tab of elements.detailTabs) {
     tab.addEventListener('click', () => setActiveDetail(tab.dataset.detail));
   }
-  elements.refreshButton.addEventListener('click', () => void refreshSnapshot());
+  elements.refreshButton.addEventListener('click', () => {
+    if (state.activeSection === 'performance') void refreshPerformance();
+    else void refreshSnapshot();
+  });
+  for (const button of document.querySelectorAll('.section-header [data-performance-action]')) {
+    button.addEventListener('click', () => void runPerformanceAction(button.dataset.performanceAction));
+  }
+  elements.performanceContent.addEventListener('click', event => {
+    const scope = event.target.closest('[data-performance-scope]');
+    if (scope) {
+      state.performance.traceScope = scope.dataset.performanceScope;
+      renderPerformance();
+      return;
+    }
+    const button = event.target.closest('[data-performance-action]');
+    if (button && !button.disabled) void runPerformanceAction(button.dataset.performanceAction);
+  });
+  elements.performanceContent.addEventListener('input', event => {
+    if (event.target.id === 'performanceDurationInput') {
+      state.performance.durationSeconds = Math.max(0.1, Math.min(15, Number(event.target.value) || 3));
+      return;
+    }
+    if (event.target.id !== 'performanceTraceFilter') return;
+    const selectionStart = event.target.selectionStart;
+    const selectionEnd = event.target.selectionEnd;
+    state.performance.traceSearch = event.target.value;
+    renderPerformance();
+    const filter = document.getElementById('performanceTraceFilter');
+    filter?.focus();
+    if (selectionStart !== null && selectionEnd !== null) filter?.setSelectionRange(selectionStart, selectionEnd);
+  });
+  elements.performanceContent.addEventListener(
+    'toggle',
+    event => {
+      if (event.target?.tagName === 'DETAILS' && event.target.classList.contains('performance-navigation')) {
+        state.performance.navigationExpanded = event.target.open;
+      }
+    },
+    true,
+  );
   elements.autoRefreshToggle.addEventListener('change', () => {
     state.autoRefresh = elements.autoRefreshToggle.checked;
     if (state.autoRefresh) {
@@ -905,9 +1576,13 @@ function wireEvents() {
       applyTheme(event.data.theme);
     }
   });
-  window.addEventListener('pagehide', stopConsoleStream);
+  window.addEventListener('pagehide', () => {
+    stopConsoleStream();
+    stopPerformanceOnPageHide();
+  });
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden && state.activeSection === 'elements') void refreshSnapshot();
+    if (!document.hidden && state.activeSection === 'performance') void refreshPerformance({ silent: true });
   });
 }
 

--- a/npm_modules/cli/src/debugger/devtoolsPanel.spec.ts
+++ b/npm_modules/cli/src/debugger/devtoolsPanel.spec.ts
@@ -602,3 +602,526 @@ describe('integrated DevTools console panel', () => {
     ]);
   });
 });
+
+interface DevToolsPerformancePanel {
+  document: { activeElement: { id?: string } | null };
+  performanceContent: {
+    innerHTML: string;
+    scrollTop: number;
+    querySelector(selector: string): { scrollLeft: number; scrollTop: number } | null;
+  };
+  state: {
+    activeSection: string;
+    performance: {
+      data: Record<string, unknown> | null;
+      durationSeconds: number;
+      error: string | null;
+      lastTrace: Record<string, unknown> | null;
+      ownerIdentity: Record<string, string> | null;
+      pending: boolean;
+      samples: Array<Record<string, number>>;
+      snapshotPending: boolean;
+      traceActive: boolean;
+      traceScope: string;
+      traceSearch: string;
+    };
+    target: { id: string; sessionId: string } | null;
+  };
+  buildPerformanceTraceExport(result: Record<string, unknown>): { traceEvents: Array<Record<string, unknown>> };
+  dispatchWindowEvent(type: string): void;
+  preparePerformanceForTargetChange(): void;
+  refreshPerformance(options?: Record<string, unknown>): Promise<void>;
+  renderPerformance(data?: Record<string, unknown>): void;
+  runPerformanceAction(action: string): Promise<void>;
+}
+
+describe('integrated DevTools performance panel', () => {
+  let panel: DevToolsPerformancePanel;
+  let requests: Array<{ body?: string; keepalive?: boolean; method: string; url: string }>;
+  let nextFetchResponse: Promise<{ ok: boolean; status: number; json(): Promise<Record<string, unknown>> }> | undefined;
+  let traceRecording: boolean;
+  let completionErrorPending: boolean;
+  let stopFailure: string | null;
+  let snapshotResponse: Record<string, unknown>;
+
+  const snapshot = {
+    mainThread: { layoutDurationMs: 2, scriptDurationMs: 4, taskDurationMs: 12 },
+    memory: { totalBytes: 4096, usedBytes: 2048 },
+    navigation: { domContentLoadedMs: 30, loadMs: 50 },
+    paints: [{ name: 'first-contentful-paint', startTime: 25 }],
+    rendererTracingEnabled: true,
+    resourceCount: 4,
+    transferSize: 1024,
+    uptimeMs: 100,
+  };
+
+  function traceResult(): Record<string, unknown> {
+    return {
+      browserMetrics: { LayoutCount: 2, TaskDurationMs: 12 },
+      browserSummary: { browserEventCount: 1, longTaskCount: 1, rendererEventCount: 1 },
+      droppedTraceEventCount: 0,
+      elapsedMs: 100,
+      perfettoMetadata: { captureScope: 'process-wide' },
+      recording: false,
+      traceCount: 2,
+      traces: [
+        { endMicros: 1300, startMicros: 1000, threadId: 1, trace: 'Valdi.Renderer.onRender.Example' },
+        { endMicros: 76_500, startMicros: 1500, threadId: 1, trace: 'Browser.MainThread.Task' },
+      ],
+    };
+  }
+
+  beforeEach(() => {
+    requests = [];
+    nextFetchResponse = undefined;
+    traceRecording = false;
+    completionErrorPending = false;
+    stopFailure = null;
+    snapshotResponse = snapshot;
+    const treeModelSource = fs.readFileSync(path.resolve(process.cwd(), 'debugger', 'debugger-tree-model.js'), 'utf8');
+    const rawPanelSource = fs.readFileSync(path.resolve(process.cwd(), 'debugger', 'devtools-panel.js'), 'utf8');
+    const panelSource = rawPanelSource.replace('void connectToInspectedApplication();', 'void 0;');
+    const elements = new Map<string, Record<string, unknown>>();
+    const document = {
+      activeElement: null as { id?: string } | null,
+      addEventListener() {},
+      createElement() {
+        return { click() {} };
+      },
+      documentElement: { dataset: {} },
+      getElementById(id: string): Record<string, unknown> {
+        let element = elements.get(id);
+        if (element === undefined) {
+          element = {
+            checked: true,
+            className: '',
+            classList: { contains: () => false, toggle() {} },
+            dataset: {},
+            innerHTML: '',
+            scrollHeight: 0,
+            scrollTop: 0,
+            style: {},
+            textContent: '',
+            value: '',
+            addEventListener() {},
+            contains: () => false,
+            focus() {},
+            removeAttribute() {},
+            querySelector: () => null,
+            setAttribute() {},
+            setSelectionRange() {},
+          };
+          elements.set(id, element);
+        }
+        return element;
+      },
+      querySelectorAll(): unknown[] {
+        return [];
+      },
+    };
+    const windowListeners = new Map<string, Array<() => void>>();
+    const window = {
+      addEventListener(type: string, listener: () => void) {
+        const listeners = windowListeners.get(type) ?? [];
+        listeners.push(listener);
+        windowListeners.set(type, listeners);
+      },
+      clearInterval() {},
+      clearTimeout() {},
+      confirm: () => true,
+      location: {
+        origin: 'http://127.0.0.1:18768',
+        search:
+          '?inspectedUrl=http%3A%2F%2F127.0.0.1%3A54321%2Findex.html%3FvaldiDevTools%3D1&targetNonce=panel-target-nonce-123456',
+      },
+      parent: {},
+      dispatch(type: string) {
+        for (const listener of windowListeners.get(type) ?? []) listener();
+      },
+      setInterval: () => 1,
+      setTimeout: () => 1,
+    };
+
+    panel = new Script(
+      `${treeModelSource}\n${panelSource}\n({ buildPerformanceTraceExport, dispatchWindowEvent: type => window.dispatch(type), document, performanceContent: elements.performanceContent, preparePerformanceForTargetChange, refreshPerformance, renderPerformance, runPerformanceAction, state })`,
+    ).runInNewContext({
+      Blob,
+      Date,
+      EventSource: class {
+        addEventListener() {}
+        close() {}
+      },
+      URL,
+      URLSearchParams,
+      console,
+      document,
+      elements,
+      fetch: (url: URL, options: { body?: string; keepalive?: boolean; method: string }) => {
+        const requestUrl = new URL(url.toString());
+        requests.push({
+          ...(options.body === undefined ? {} : { body: options.body }),
+          ...(options.keepalive === undefined ? {} : { keepalive: options.keepalive }),
+          method: options.method,
+          url: requestUrl.toString(),
+        });
+        if (nextFetchResponse) {
+          const response = nextFetchResponse;
+          nextFetchResponse = undefined;
+          return response;
+        }
+        let payload: Record<string, unknown>;
+        if (requestUrl.pathname.endsWith('/snapshot')) {
+          payload = snapshotResponse;
+        } else if (requestUrl.pathname.endsWith('/status')) {
+          payload = {
+            completedRecordingAvailable: false,
+            ...(completionErrorPending ? { completionError: 'Synthetic retained completion error.' } : {}),
+            recording: traceRecording,
+            rendererTracingEnabled: true,
+            tracingSupported: true,
+          };
+        } else if (requestUrl.pathname.endsWith('/start')) {
+          traceRecording = true;
+          payload = { recording: true, rendererTracingEnabled: true, tracingSupported: true };
+        } else if (requestUrl.pathname.endsWith('/enable')) {
+          payload = { rendererTracingEnabled: true };
+        } else if (requestUrl.pathname.endsWith('/stop') && completionErrorPending) {
+          completionErrorPending = false;
+          return Promise.resolve({
+            json: () => Promise.resolve({ error: 'Synthetic retained completion error.' }),
+            ok: false,
+            status: 500,
+          });
+        } else if (requestUrl.pathname.endsWith('/stop') && stopFailure) {
+          const error = stopFailure;
+          stopFailure = null;
+          return Promise.resolve({ json: () => Promise.resolve({ error }), ok: false, status: 500 });
+        } else {
+          traceRecording = false;
+          payload = traceResult();
+        }
+        return Promise.resolve({ json: () => Promise.resolve(payload), ok: true, status: 200 });
+      },
+      navigator: { clipboard: { writeText: () => Promise.resolve() } },
+      window,
+    }) as DevToolsPerformancePanel;
+    panel.state.activeSection = 'performance';
+    panel.state.target = { id: 'owl:web-preview', sessionId: 'web-preview' };
+  });
+
+  it('binds snapshots and status polling to the complete inspected-target tuple', async () => {
+    await panel.refreshPerformance();
+
+    expect(requests.length).toBe(2);
+    for (const request of requests) {
+      const url = new URL(request.url);
+      expect(url.searchParams.get('sessionId')).toBe('web-preview');
+      expect(url.searchParams.get('inspectedUrl')).toBe('http://127.0.0.1:54321/index.html?valdiDevTools=1');
+      expect(url.searchParams.get('targetNonce')).toBe('panel-target-nonce-123456');
+    }
+    expect(panel.state.performance.samples.length).toBe(1);
+    expect(panel.performanceContent.innerHTML).toContain('data-performance-scope="valdi"');
+    expect(panel.performanceContent.innerHTML).toContain('data-performance-scope="browser"');
+    expect(panel.performanceContent.innerHTML).toContain('data-performance-scope="all"');
+    expect(panel.performanceContent.innerHTML).not.toContain('data-performance-scope="app"');
+    expect(panel.performanceContent.innerHTML).toContain('JavaScript time');
+    expect(panel.performanceContent.innerHTML).toContain('Layout time');
+    expect(panel.performanceContent.innerHTML).toContain('<button type="button"');
+  });
+
+  it('links the Performance tab and panel with tab semantics', () => {
+    const html = fs.readFileSync(path.resolve(process.cwd(), 'debugger', 'devtools-panel.html'), 'utf8');
+
+    expect(html).toContain('id="performanceTab"');
+    expect(html).toContain('aria-controls="performanceSection"');
+    expect(html).toContain('id="performanceSection"');
+    expect(html).toMatch(/role="tabpanel"\s+aria-labelledby="performanceTab"/);
+  });
+
+  it('clamps capture to fifteen seconds and never calls a CPU profiling route', async () => {
+    panel.state.performance.data = snapshot;
+    panel.state.performance.durationSeconds = 90;
+
+    await panel.runPerformanceAction('trace-capture');
+
+    const capture = requests.find(request => new URL(request.url).pathname.endsWith('/trace/capture'));
+    if (!capture?.body) throw new Error('Expected a trace capture request.');
+    expect(JSON.parse(capture.body)).toEqual({ durationMs: 15_000 });
+    expect(new URL(capture.url).searchParams.get('sessionId')).toBe('web-preview');
+    expect(requests.some(request => request.url.includes('/profile/'))).toBeFalse();
+    expect(panel.state.performance.lastTrace).toEqual(jasmine.objectContaining({ traceCount: 2 }));
+  });
+
+  it('keeps the recording owner tuple when stopping after the selected target changes', async () => {
+    panel.state.performance.data = snapshot;
+    await panel.runPerformanceAction('trace-start');
+    expect(panel.state.performance.traceActive).toBeTrue();
+    expect(panel.state.performance.ownerIdentity).toEqual(
+      jasmine.objectContaining({ sessionId: 'web-preview', targetNonce: 'panel-target-nonce-123456' }),
+    );
+
+    panel.state.performance.lastTrace = traceResult();
+    panel.preparePerformanceForTargetChange();
+    expect(panel.state.performance.data).toBeNull();
+    expect(panel.state.performance.lastTrace).toBeNull();
+    expect(panel.state.performance.samples).toEqual([]);
+    panel.state.target = { id: 'owl:replacement', sessionId: 'replacement' };
+    snapshotResponse = { ...snapshot, resourceCount: 9, uptimeMs: 200 };
+    await panel.runPerformanceAction('trace-stop');
+
+    const stop = requests.find(request => new URL(request.url).pathname.endsWith('/trace/stop'));
+    if (!stop) throw new Error('Expected a trace stop request.');
+    expect(new URL(stop.url).searchParams.get('sessionId')).toBe('web-preview');
+    expect(panel.state.performance.traceActive).toBeFalse();
+    expect(panel.state.performance.ownerIdentity).toBeNull();
+    expect(panel.state.performance.lastTrace).toBeNull();
+    expect(panel.state.performance.data).toEqual(jasmine.objectContaining({ resourceCount: 9 }));
+    expect(panel.state.performance.samples.length).toBe(1);
+  });
+
+  it('acknowledges a retained completion error through Stop before allowing another Start', async () => {
+    panel.state.performance.data = snapshot;
+    panel.state.performance.traceActive = true;
+    panel.state.performance.ownerIdentity = {
+      inspectedUrl: 'http://127.0.0.1:54321/index.html?valdiDevTools=1',
+      sessionId: 'web-preview',
+      targetNonce: 'panel-target-nonce-123456',
+    };
+    completionErrorPending = true;
+
+    await panel.refreshPerformance();
+
+    const acknowledgement = requests.find(request => new URL(request.url).pathname.endsWith('/trace/stop'));
+    if (!acknowledgement) throw new Error('Expected completion-error acknowledgement through Stop.');
+    expect(new URL(acknowledgement.url).searchParams.get('sessionId')).toBe('web-preview');
+    expect(panel.state.performance.error).toBe('Synthetic retained completion error.');
+    expect(completionErrorPending).toBeFalse();
+    expect(panel.state.performance.traceActive).toBeFalse();
+    expect(panel.state.performance.ownerIdentity).toBeNull();
+
+    await panel.runPerformanceAction('trace-start');
+    expect(panel.state.performance.traceActive).toBeTrue();
+  });
+
+  it('invalidates an old snapshot without wedging polling when the target changes', async () => {
+    let resolveSnapshot:
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
+    nextFetchResponse = new Promise(resolve => {
+      resolveSnapshot = resolve;
+    });
+    const oldRefresh = panel.refreshPerformance();
+    await Promise.resolve();
+    expect(panel.state.performance.snapshotPending).toBeTrue();
+
+    panel.preparePerformanceForTargetChange();
+    panel.state.target = { id: 'owl:replacement', sessionId: 'replacement' };
+    expect(panel.state.performance.snapshotPending).toBeFalse();
+    if (!resolveSnapshot) throw new Error('Expected a deferred performance snapshot.');
+    resolveSnapshot({ json: () => Promise.resolve(snapshot), ok: true, status: 200 });
+    await oldRefresh;
+
+    expect(panel.state.performance.data).toBeNull();
+    await panel.refreshPerformance();
+    expect(panel.state.performance.data).toEqual(snapshot);
+    expect(panel.state.performance.snapshotPending).toBeFalse();
+  });
+
+  it('does not let a delayed pre-start status response overwrite a successful Start', async () => {
+    panel.state.performance.data = snapshot;
+    let resolveSnapshot:
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
+    nextFetchResponse = new Promise(resolve => {
+      resolveSnapshot = resolve;
+    });
+    const oldPoll = panel.refreshPerformance({ silent: true });
+    await Promise.resolve();
+
+    await panel.runPerformanceAction('trace-start');
+    if (!resolveSnapshot) throw new Error('Expected a deferred pre-start snapshot.');
+    resolveSnapshot({ json: () => Promise.resolve(snapshot), ok: true, status: 200 });
+    await oldPoll;
+
+    expect(panel.state.performance.traceActive).toBeTrue();
+    expect(panel.state.performance.ownerIdentity).toEqual(jasmine.objectContaining({ sessionId: 'web-preview' }));
+  });
+
+  it('cleans up a stale successful start without overwriting the replacement target', async () => {
+    panel.state.performance.data = snapshot;
+    let resolveStart:
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
+    nextFetchResponse = new Promise(resolve => {
+      resolveStart = resolve;
+    });
+    const start = panel.runPerformanceAction('trace-start');
+    await Promise.resolve();
+
+    panel.preparePerformanceForTargetChange();
+    panel.state.target = { id: 'owl:replacement', sessionId: 'replacement' };
+    if (!resolveStart) throw new Error('Expected a deferred performance start.');
+    resolveStart({
+      json: () => Promise.resolve({ recording: true, rendererTracingEnabled: true, tracingSupported: true }),
+      ok: true,
+      status: 200,
+    });
+    await start;
+
+    const startRequest = requests.find(request => new URL(request.url).pathname.endsWith('/trace/start'));
+    const cleanupRequest = requests.find(request => new URL(request.url).pathname.endsWith('/trace/stop'));
+    if (!startRequest || !cleanupRequest) throw new Error('Expected stale-start cleanup requests.');
+    expect(new URL(startRequest.url).searchParams.get('sessionId')).toBe('web-preview');
+    expect(new URL(cleanupRequest.url).searchParams.get('sessionId')).toBe('web-preview');
+    expect(panel.state.target?.sessionId).toBe('replacement');
+    expect(panel.state.performance.traceActive).toBeFalse();
+    expect(panel.state.performance.ownerIdentity).toBeNull();
+    expect(panel.state.performance.pending).toBeFalse();
+  });
+
+  it('retains and surfaces a stale Start owner when exact cleanup fails', async () => {
+    panel.state.performance.data = snapshot;
+    let resolveStart:
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
+    nextFetchResponse = new Promise(resolve => {
+      resolveStart = resolve;
+    });
+    const start = panel.runPerformanceAction('trace-start');
+    await Promise.resolve();
+
+    panel.preparePerformanceForTargetChange();
+    panel.state.target = { id: 'owl:replacement', sessionId: 'replacement' };
+    stopFailure = 'Synthetic stale cleanup failure.';
+    if (!resolveStart) throw new Error('Expected a deferred performance start.');
+    resolveStart({
+      json: () => Promise.resolve({ recording: true, rendererTracingEnabled: true, tracingSupported: true }),
+      ok: true,
+      status: 200,
+    });
+    await start;
+
+    expect(panel.state.performance.traceActive).toBeTrue();
+    expect(panel.state.performance.ownerIdentity).toEqual(jasmine.objectContaining({ sessionId: 'web-preview' }));
+    expect(panel.state.performance.error).toContain('Synthetic stale cleanup failure.');
+    expect(panel.performanceContent.innerHTML).toContain('Stop and retrieve');
+
+    await panel.runPerformanceAction('trace-stop');
+    const stopRequests = requests.filter(request => new URL(request.url).pathname.endsWith('/trace/stop'));
+    expect(stopRequests.length).toBe(2);
+    expect(new URL(stopRequests[1]?.url ?? '').searchParams.get('sessionId')).toBe('web-preview');
+    expect(panel.state.performance.ownerIdentity).toBeNull();
+  });
+
+  it('keeps an in-flight Capture owned across a target change without publishing its old result', async () => {
+    panel.state.performance.data = snapshot;
+    let resolveCapture:
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
+    nextFetchResponse = new Promise(resolve => {
+      resolveCapture = resolve;
+    });
+    const capture = panel.runPerformanceAction('trace-capture');
+    await Promise.resolve();
+    expect(panel.state.performance.traceActive).toBeTrue();
+    expect(panel.state.performance.ownerIdentity).toEqual(jasmine.objectContaining({ sessionId: 'web-preview' }));
+
+    panel.preparePerformanceForTargetChange();
+    panel.state.target = { id: 'owl:replacement', sessionId: 'replacement' };
+    expect(panel.state.performance.data).toBeNull();
+    expect(panel.state.performance.ownerIdentity).toEqual(jasmine.objectContaining({ sessionId: 'web-preview' }));
+    if (!resolveCapture) throw new Error('Expected a deferred performance capture.');
+    resolveCapture({ json: () => Promise.resolve(traceResult()), ok: true, status: 200 });
+    await capture;
+
+    expect(panel.state.performance.traceActive).toBeFalse();
+    expect(panel.state.performance.ownerIdentity).toBeNull();
+    expect(panel.state.performance.lastTrace).toBeNull();
+  });
+
+  it('skips silent polling while a generated Performance input is focused', async () => {
+    panel.state.performance.data = snapshot;
+    panel.document.activeElement = { id: 'performanceTraceFilter' };
+
+    await panel.refreshPerformance({ silent: true });
+
+    expect(requests).toEqual([]);
+    expect(panel.state.performance.data).toBe(snapshot);
+  });
+
+  it('preserves panel and timeline scroll positions when polling rerenders', () => {
+    const previousTimeline = { scrollLeft: 83, scrollTop: 47 };
+    const replacementTimeline = { scrollLeft: 0, scrollTop: 0 };
+    let queryCount = 0;
+    panel.performanceContent.scrollTop = 129;
+    panel.performanceContent.querySelector = () => (queryCount++ === 0 ? previousTimeline : replacementTimeline);
+
+    panel.renderPerformance(snapshot);
+
+    expect(panel.performanceContent.scrollTop).toBe(129);
+    expect(replacementTimeline.scrollLeft).toBe(83);
+    expect(replacementTimeline.scrollTop).toBe(47);
+  });
+
+  it('uses an exact-owner keepalive Stop when the panel unloads', async () => {
+    panel.state.performance.data = snapshot;
+    await panel.runPerformanceAction('trace-start');
+    requests = [];
+
+    panel.dispatchWindowEvent('pagehide');
+    await Promise.resolve();
+
+    const stop = requests.find(request => new URL(request.url).pathname.endsWith('/trace/stop'));
+    if (!stop) throw new Error('Expected a pagehide trace stop request.');
+    expect(stop.keepalive).toBeTrue();
+    expect(new URL(stop.url).searchParams.get('sessionId')).toBe('web-preview');
+    expect(new URL(stop.url).searchParams.get('targetNonce')).toBe('panel-target-nonce-123456');
+  });
+
+  it('bounds samples, timeline rows, and grouped summary rows', () => {
+    const traces = Array.from({ length: 180 }, (_, index) => ({
+      endMicros: index * 1000 + 500,
+      startMicros: index * 1000,
+      threadId: 1,
+      trace: `Valdi.Operation.${index % 20}`,
+    }));
+    panel.state.performance.lastTrace = { ...traceResult(), traceCount: traces.length, traces };
+    for (let index = 0; index < 125; index++) {
+      panel.renderPerformance({ ...snapshot, uptimeMs: index + 1 });
+    }
+
+    const timelineRows = panel.performanceContent.innerHTML.match(/class="performance-timeline-row"/g) ?? [];
+    const summaryRows = panel.performanceContent.innerHTML.match(/<tr><td>Valdi\.Operation\./g) ?? [];
+    expect(panel.state.performance.samples.length).toBe(120);
+    expect(timelineRows.length).toBe(120);
+    expect(summaryRows.length).toBe(12);
+    expect(panel.performanceContent.innerHTML).toContain('Total captured duration by event');
+    expect(panel.performanceContent.innerHTML).toContain('Inclusive total');
+  });
+
+  it('builds the export only on demand without requiring duplicated raw or Perfetto event lists', () => {
+    const result = traceResult();
+    const exported = panel.buildPerformanceTraceExport(result);
+
+    expect(result['rawTraceEvents']).toBeUndefined();
+    expect(result['perfetto']).toBeUndefined();
+    expect(exported.traceEvents.filter(event => event['ph'] === 'X').length).toBe(2);
+    expect(exported.traceEvents.length).toBe(4);
+  });
+
+  it('escapes filtered trace names in the panel while preserving them in on-demand export', () => {
+    const maliciousName = 'Valdi.<img src=x onerror=alert(1)>';
+    const result = traceResult();
+    const traces = result['traces'] as Array<Record<string, unknown>>;
+    traces.push({ endMicros: 77_000, startMicros: 76_700, threadId: 1, trace: maliciousName });
+    panel.state.performance.lastTrace = { ...result, traceCount: traces.length };
+    panel.state.performance.traceSearch = 'onerror';
+
+    panel.renderPerformance(snapshot);
+    const exported = panel.buildPerformanceTraceExport(result);
+
+    expect(panel.performanceContent.innerHTML).not.toContain('<img src=x');
+    expect(panel.performanceContent.innerHTML).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(exported.traceEvents).toContain(jasmine.objectContaining({ name: maliciousName }));
+  });
+});


### PR DESCRIPTION
## Description

Adds a generation-safe Performance panel over the preceding bounded capture API.

- Keeps Start, Stop, polling, and completed results bound to one exact target generation.
- Preserves focus and scroll while rejecting stale or ambiguous capture state.
- Cleans up ownership on target changes, aborts, and page lifecycle events.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation improvement
- [ ] Performance optimization
- [x] Test improvement
- [x] Other (new debugger capability)

## Testing
- [ ] Tests pass locally (`bazel test //...`)
- [x] Added/updated tests for changes (if applicable)
- [ ] Tested on multiple platforms (iOS/Android/Web/macOS as applicable)
- [ ] Manual testing performed (describe below)

### Testing Details
- Incremental branch: Panel 25/25, combined focused 114/114, full CLI 347/347, production build, TypeScript, lint, format, syntax, and query passed.
- Assembled debugger stack: `npm test` passed 436/436; the CLI production build passed.
- Focused `//src/valdi_modules/src/valdi/web_renderer:test` passed.
- `bazel query //...` passed.
- The broad Valdi suite reproduced the established 12 unrelated failures; all new debugger specs passed.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in description)
- [x] Commit messages follow [conventional format](../CONTRIBUTING.md#commit-messages)
- [x] No secrets, API keys, or internal URLs included

## Related Issues
Relates to #154

## Additional Context
Stack 15/22. Stacked on #167 (`bjd/debugger-web-performance-api`). Review this PR as the single incremental commit `c1d9db42` against that base; do not merge it before its parent.