### PR TITLE
Add bounded runtime-state inspection

### DIFF
--- a/npm_modules/cli/debugger/README.md
+++ b/npm_modules/cli/debugger/README.md
@@ -21,7 +21,7 @@ the CLI package.
 - `debugger-actions.js`: UI actions, command prompt handling, auto-refresh, and externally driven debugger actions.
 - `debugger-session.js`: `sessionStorage` restore/persist for reload-friendly debugger state.
 - `debugger-bootstrap.js`: DOM event wiring and boot sequence.
-- `devtools-panel.html`, `devtools-panel.css`, and `devtools-panel.js`: the focused Chromium Elements, Console, and bounded Performance panel embedded by the generated extension.
+- `devtools-panel.html`, `devtools-panel.css`, and `devtools-panel.js`: the focused Chromium Elements, State, Console, and bounded Performance panel embedded by the generated extension.
 
 Scripts are loaded as classic browser scripts in the order listed in
 `index.html`. There is no module loader or bundler for this frontend; shared
@@ -60,6 +60,45 @@ materialize their complete key result before the cap is applied. A throwing or
 revoked Proxy therefore causes that component's properties to be omitted while
 preserving the hierarchy. Prototype traversal is not used, and property values
 are never read through normal property access.
+
+The same web hierarchy snapshot may include read-only component runtime state
+without adding a route, capability, or renderer API. This is taken from the
+exact component instance, not its ViewModel, and only from an own, enumerable
+data descriptor named `state` whose value is a non-null object. Getters,
+inherited fields, scalar state, and throwing reflection are omitted. The state
+object is detached under the existing descriptor-only snapshot rules, encoded
+as JSON, and admitted only when the exact escaped `component.state` wire string
+fits the component snapshot's remaining 64 KiB UTF-8 budget after properties.
+Detached and escaped-wire projection work is also bounded across the complete
+hierarchy by separate byte, reflection, and attempt counters; indeterminate
+nested reflection exhausts that State-only work budget without affecting
+component properties or hierarchy capture. Own-key enumeration itself is not
+resumable, so a Proxy may still materialize one complete key list. State checks
+that list against its remaining reflection allowance before performing any
+per-name descriptor lookup, and checks the allowance again before every nested
+object or array descriptor lookup.
+The pre-existing property-edit metadata is not debited from that counter and
+remains bounded by the complete snapshot envelope. Topology revalidation binds
+the same virtual node and component instance; an ineligible descriptor or
+changed raw state identity removes only `component.state`, while ViewModel
+replacement continues to remove only properties and edit metadata. If the
+final hierarchy envelope is too large, runtime state is stripped and retried
+before existing component properties and edit metadata are stripped.
+
+Native detailed snapshots retain their existing human-readable
+`IRenderedVirtualNodeData.state` string and are not changed by this web capture.
+The State panel determines the serialization format from the target identity.
+Inspected Chromium web snapshots accept strict JSON only. Native debug strings
+do not escape keys, quoted contents, function names, error text, or marker text,
+so every direct native snapshot is displayed as escaped raw text rather than
+interpreted structurally. Raw display remains searchable. Input is capped at
+65,536 characters; parsed web input is additionally capped at depth 12, tokens 2,000,
+entries per container at 100, and keys at 1,024 characters. Parsed records have
+null prototypes and are populated with data descriptors. Rendering is further
+capped at 500 stateful components and 1,000 value rows. Main-panel search and
+disclosures are independent from selected-component State details, and every
+Inspect action is bound to the exact current snapshot node and render
+generation.
 
 An accepted web snapshot may additionally promote the separate
 `component-property-edit` capability when both the renderer's dedicated

--- a/npm_modules/cli/debugger/devtools-panel.css
+++ b/npm_modules/cli/debugger/devtools-panel.css
@@ -616,6 +616,189 @@ button {
   word-break: break-word;
 }
 
+.runtime-state-toolbar {
+  justify-content: flex-start;
+  gap: 9px;
+}
+
+.runtime-state-summary {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+.runtime-state-filter {
+  width: min(320px, 48vw);
+  min-width: 120px;
+  height: 23px;
+  margin-left: auto;
+  padding: 0 7px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  outline: none;
+  background: var(--background);
+  color: var(--text);
+  font-size: 11px;
+}
+
+.runtime-state-filter:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.runtime-state-content {
+  padding: 0;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.runtime-state-component {
+  position: relative;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.runtime-state-component-details {
+  min-width: 0;
+}
+
+.runtime-state-component-summary,
+.runtime-state-value-summary {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  list-style: none;
+  cursor: pointer;
+}
+
+.runtime-state-component-summary {
+  min-height: 34px;
+  padding: 4px 68px 4px 9px;
+  gap: 7px;
+}
+
+.runtime-state-component-summary::-webkit-details-marker,
+.runtime-state-value-summary::-webkit-details-marker {
+  display: none;
+}
+
+.runtime-state-component-summary:hover,
+.runtime-state-value-summary:hover,
+.runtime-state-inspect:hover,
+.runtime-state-inspect:focus-visible {
+  background: var(--surface-hover);
+}
+
+.runtime-state-disclosure {
+  width: 10px;
+  flex: 0 0 auto;
+  color: var(--muted);
+}
+
+.runtime-state-component-details[open] > .runtime-state-component-summary > .runtime-state-disclosure,
+details[open] > .runtime-state-value-summary > .runtime-state-disclosure {
+  transform: rotate(90deg);
+}
+
+.runtime-state-component-name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--tag);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-state-component-key,
+.runtime-state-component-description,
+.runtime-state-limit {
+  color: var(--muted);
+}
+
+.runtime-state-component-key,
+.runtime-state-component-description {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-state-component-description {
+  margin-left: auto;
+}
+
+.runtime-state-inspect {
+  position: absolute;
+  top: 5px;
+  right: 8px;
+  flex: 0 0 auto;
+  padding: 3px 6px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--accent);
+}
+
+.runtime-state-component-body {
+  padding: 4px 10px 9px 25px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.runtime-state-value-row {
+  min-height: 20px;
+  overflow-wrap: anywhere;
+}
+
+.runtime-state-value-details {
+  margin-left: 10px;
+}
+
+.runtime-state-value-summary {
+  min-height: 20px;
+  gap: 4px;
+}
+
+.runtime-state-value-children {
+  margin-left: 10px;
+  padding-left: 8px;
+  border-left: 1px solid var(--border-soft);
+}
+
+.runtime-state-value-key {
+  color: var(--attribute);
+}
+
+.runtime-state-value-string {
+  color: var(--string);
+}
+
+.runtime-state-value-number,
+.runtime-state-value-boolean,
+.runtime-state-value-null {
+  color: var(--number);
+}
+
+.runtime-state-value-description {
+  color: var(--muted);
+}
+
+.runtime-state-raw {
+  max-height: 260px;
+  margin: 0;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.runtime-state-inspector {
+  margin-bottom: 12px;
+}
+
+.runtime-state-limit {
+  padding: 7px 0;
+  font-style: italic;
+}
+
 .breadcrumb-bar {
   padding: 0 8px;
   border-top: 1px solid var(--border);

--- a/npm_modules/cli/debugger/devtools-panel.html
+++ b/npm_modules/cli/debugger/devtools-panel.html
@@ -23,6 +23,18 @@
             Elements
           </button>
           <button
+            id="stateTab"
+            type="button"
+            class="main-tab"
+            data-section="state"
+            role="tab"
+            aria-controls="stateSection"
+            aria-selected="false"
+            tabindex="-1"
+          >
+            State
+          </button>
+          <button
             id="performanceTab"
             type="button"
             class="main-tab"
@@ -115,22 +127,90 @@
           <section class="inspector-pane" aria-label="Selected element inspector">
             <div class="inspector-toolbar">
               <nav class="detail-tabs" aria-label="Element inspection" role="tablist">
-                <button class="detail-tab selected" data-detail="styles" role="tab" aria-selected="true">Styles</button>
-                <button class="detail-tab" data-detail="computed" role="tab" aria-selected="false">Computed</button>
-                <button class="detail-tab" data-detail="dom" role="tab" aria-selected="false">DOM</button>
+                <button
+                  id="stylesDetailTab"
+                  type="button"
+                  class="detail-tab selected"
+                  data-detail="styles"
+                  role="tab"
+                  aria-controls="inspector"
+                  aria-selected="true"
+                  tabindex="0"
+                >
+                  Styles
+                </button>
+                <button
+                  id="computedDetailTab"
+                  type="button"
+                  class="detail-tab"
+                  data-detail="computed"
+                  role="tab"
+                  aria-controls="inspector"
+                  aria-selected="false"
+                  tabindex="-1"
+                >
+                  Computed
+                </button>
+                <button
+                  id="stateDetailTab"
+                  type="button"
+                  class="detail-tab"
+                  data-detail="state"
+                  role="tab"
+                  aria-controls="inspector"
+                  aria-selected="false"
+                  tabindex="-1"
+                >
+                  State
+                </button>
+                <button
+                  id="domDetailTab"
+                  type="button"
+                  class="detail-tab"
+                  data-detail="dom"
+                  role="tab"
+                  aria-controls="inspector"
+                  aria-selected="false"
+                  tabindex="-1"
+                >
+                  DOM
+                </button>
               </nav>
               <div class="toolbar-spacer"></div>
               <button id="copyNodeButton" class="icon-button" title="Copy selected node JSON" aria-label="Copy node">
                 <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M7 6h9v10H7zM4 13V4h9" /></svg>
               </button>
             </div>
-            <div id="inspector" class="inspector"></div>
+            <div id="inspector" class="inspector" role="tabpanel" aria-labelledby="stylesDetailTab"></div>
           </section>
 
           <footer class="breadcrumb-bar">
             <div id="breadcrumbs" class="breadcrumbs"></div>
             <span id="nodeSummary" class="node-summary"></span>
           </footer>
+        </section>
+
+        <section
+          id="stateSection"
+          class="section utility-section"
+          data-panel="state"
+          role="tabpanel"
+          aria-labelledby="stateTab"
+          hidden
+        >
+          <div class="section-header runtime-state-toolbar">
+            <span>Component state</span>
+            <span id="stateSummary" class="runtime-state-summary" role="status" aria-live="polite"></span>
+            <input
+              id="stateFilter"
+              class="runtime-state-filter"
+              type="search"
+              placeholder="Filter components, keys, or values"
+              aria-label="Filter component state"
+              autocomplete="off"
+            />
+          </div>
+          <div id="stateContent" class="utility-content runtime-state-content"></div>
         </section>
 
         <section

--- a/npm_modules/cli/debugger/devtools-panel.js
+++ b/npm_modules/cli/debugger/devtools-panel.js
@@ -10,10 +10,23 @@ const MAX_CONSOLE_HISTORY_ENTRIES = 100;
 const MAX_PERFORMANCE_SAMPLES = 120;
 const MAX_PERFORMANCE_TIMELINE_ROWS = 120;
 const MAX_PERFORMANCE_SUMMARY_ROWS = 12;
+const MAX_RUNTIME_STATE_CHARACTERS = 65_536;
+const MAX_RUNTIME_STATE_COMPONENT_ROWS = 500;
+const MAX_RUNTIME_STATE_CONTAINER_ENTRIES = 100;
+const MAX_RUNTIME_STATE_DEPTH = 12;
+const MAX_RUNTIME_STATE_KEY_CHARACTERS = 1_024;
+const MAX_RUNTIME_STATE_TOKENS = 2_000;
+const MAX_RUNTIME_STATE_VALUE_ROWS = 1_000;
+const RUNTIME_STATE_SOURCE_NATIVE = 'native';
+const RUNTIME_STATE_SOURCE_WEB = 'web';
 const COMPONENT_PROPERTY_TOKEN_PATTERN = /^[0-9a-f]{32}$/;
 const COMPONENT_PROPERTY_EDIT_ERROR = 'The component property edit is stale or invalid.';
+const SNAPSHOT_REFRESH_APPLIED = 'applied';
+const SNAPSHOT_REFRESH_RUNTIME_STATE_DEFERRED = 'runtime-state-deferred';
+const SNAPSHOT_REFRESH_SKIPPED = 'skipped';
 const FORBIDDEN_COMPONENT_PROPERTY_NAMES = new Set(['__proto__', 'children', 'constructor', 'prototype']);
 const componentPropertyEditorBindings = new WeakMap();
+const runtimeStateInspectBindings = new WeakMap();
 const MANUAL_WEB_CAPABILITIES = new Set([
   'component-properties',
   'components',
@@ -123,6 +136,14 @@ const state = {
     operationGeneration: 0,
     pending: false,
   },
+  runtimeState: {
+    expandedComponents: new Set(),
+    expandedInspectorValues: new Set(),
+    expandedMainValues: new Set(),
+    inspectGeneration: 0,
+    inspectorNodeId: null,
+    search: '',
+  },
   error: null,
 };
 
@@ -154,6 +175,10 @@ const elements = {
   consoleForm: document.getElementById('consoleForm'),
   consoleInput: document.getElementById('consoleInput'),
   performanceContent: document.getElementById('performanceContent'),
+  stateContent: document.getElementById('stateContent'),
+  stateFilter: document.getElementById('stateFilter'),
+  stateSection: document.getElementById('stateSection'),
+  stateSummary: document.getElementById('stateSummary'),
 };
 
 function escapeHtml(value) {
@@ -327,11 +352,11 @@ function isSelectableDirectTarget(target) {
   const capabilities = targetCapabilities(target);
   return Boolean(
     target.attachable &&
-    target.state !== 'waiting' &&
-    target.identityMode === 'target-id' &&
-    target.transport === 'valdi-daemon' &&
-    capabilities.has('components') &&
-    capabilities.has('snapshot'),
+      target.state !== 'waiting' &&
+      target.identityMode === 'target-id' &&
+      target.transport === 'valdi-daemon' &&
+      capabilities.has('components') &&
+      capabilities.has('snapshot'),
   );
 }
 
@@ -515,6 +540,7 @@ function performanceBlocksTargetSwitch() {
 
 function sectionIsAvailable(section) {
   if (section === 'elements') return true;
+  if (section === 'state') return targetSupports('components') && targetSupports('snapshot');
   if (section === 'console') return targetSupports('console');
   if (section === 'performance') return targetSupports('performance') || Boolean(state.performance.ownerIdentity);
   return false;
@@ -568,6 +594,26 @@ function resetComponentPropertyEditForTargetChange() {
   state.componentPropertyEdit.error = null;
 }
 
+function resetRuntimeStateForTargetChange() {
+  const runtimeState = state.runtimeState;
+  runtimeState.inspectGeneration++;
+  runtimeState.inspectorNodeId = null;
+  runtimeState.search = '';
+  runtimeState.expandedComponents.clear();
+  runtimeState.expandedInspectorValues.clear();
+  runtimeState.expandedMainValues.clear();
+  if (elements.stateFilter) elements.stateFilter.value = '';
+  if (elements.stateSummary) elements.stateSummary.textContent = '';
+  if (elements.stateContent) elements.stateContent.innerHTML = '';
+}
+
+function resetRuntimeStateForSelectionChange(selectedNodeId) {
+  if (state.runtimeState.inspectorNodeId === selectedNodeId) return;
+  state.runtimeState.inspectGeneration++;
+  state.runtimeState.inspectorNodeId = selectedNodeId;
+  state.runtimeState.expandedInspectorValues.clear();
+}
+
 function clearTargetPresentation(message) {
   state.snapshotRequestGeneration++;
   state.refreshPending = false;
@@ -580,6 +626,7 @@ function clearTargetPresentation(message) {
   resetHighlightForTargetChange();
   resetConsoleForTargetChange();
   resetComponentPropertyEditForTargetChange();
+  resetRuntimeStateForTargetChange();
   preparePerformanceForTargetChange();
   elements.treeEmpty.textContent = message;
   render();
@@ -842,6 +889,7 @@ async function connectToInspectedPage() {
       enqueueExactHighlightClear(state.target);
       resetConsoleForTargetChange();
       resetComponentPropertyEditForTargetChange();
+      resetRuntimeStateForTargetChange();
       preparePerformanceForTargetChange();
       state.snapshotRequestGeneration++;
       state.refreshPending = false;
@@ -898,6 +946,13 @@ async function refreshSnapshot() {
   await refreshSnapshotInternal(null);
 }
 
+function runtimeStatePresentationHasFocus() {
+  const activeElement = document.activeElement;
+  if (!activeElement) return false;
+  if (elements.stateSection?.contains(activeElement)) return true;
+  return state.activeDetail === 'state' && elements.inspector?.contains(activeElement);
+}
+
 async function refreshSnapshotInternal(componentPropertyEditOperationGeneration) {
   const componentPropertyEditOwnsRefresh = () =>
     componentPropertyEditOperationGeneration !== null &&
@@ -908,13 +963,20 @@ async function refreshSnapshotInternal(componentPropertyEditOperationGeneration)
     targetSupports('components') &&
     targetSupports('snapshot') &&
     ((!state.componentPropertyEdit.focused && !state.componentPropertyEdit.pending) ||
-      componentPropertyEditOwnsRefresh());
-  if (!refreshIsAllowed()) return;
+      componentPropertyEditOwnsRefresh()) &&
+    !runtimeStatePresentationHasFocus();
+  if (!refreshIsAllowed()) {
+    return runtimeStatePresentationHasFocus() ? SNAPSHOT_REFRESH_RUNTIME_STATE_DEFERRED : SNAPSHOT_REFRESH_SKIPPED;
+  }
   if (state.refreshPending) {
     const activeRequestCompletion = state.snapshotRequestCompletion;
-    if (!componentPropertyEditOwnsRefresh() || activeRequestCompletion === null) return;
+    if (!componentPropertyEditOwnsRefresh() || activeRequestCompletion === null) {
+      return SNAPSHOT_REFRESH_SKIPPED;
+    }
     await activeRequestCompletion;
-    if (!refreshIsAllowed() || state.refreshPending) return;
+    if (!refreshIsAllowed() || state.refreshPending) {
+      return runtimeStatePresentationHasFocus() ? SNAPSHOT_REFRESH_RUNTIME_STATE_DEFERRED : SNAPSHOT_REFRESH_SKIPPED;
+    }
   }
   state.refreshPending = true;
   let resolveRequestCompletion;
@@ -931,12 +993,14 @@ async function refreshSnapshotInternal(componentPropertyEditOperationGeneration)
     state.snapshotRequestGeneration === requestGeneration;
   try {
     const snapshot = await requestJson('/api/devtools/snapshot', targetIdentityParameters(requestTarget), {});
+    if (!requestIsCurrent()) return SNAPSHOT_REFRESH_SKIPPED;
+    if (runtimeStatePresentationHasFocus()) return SNAPSHOT_REFRESH_RUNTIME_STATE_DEFERRED;
     if (
-      !requestIsCurrent() ||
-      ((state.componentPropertyEdit.focused || state.componentPropertyEdit.pending) &&
-        !componentPropertyEditOwnsRefresh())
-    )
-      return;
+      (state.componentPropertyEdit.focused || state.componentPropertyEdit.pending) &&
+      !componentPropertyEditOwnsRefresh()
+    ) {
+      return SNAPSHOT_REFRESH_SKIPPED;
+    }
     if (
       snapshot.target?.id === requestTarget.id &&
       Array.isArray(snapshot.target.capabilities) &&
@@ -948,8 +1012,10 @@ async function refreshSnapshotInternal(componentPropertyEditOperationGeneration)
     }
     snapshot.tree = valdiDebuggerTreeModel.restoreTree(snapshot.tree);
     const wasEmpty = !state.snapshot?.tree;
+    const previousSelectedNodeId = state.selectedNodeId;
     const shouldClearHighlight = state.hoveredNodeId !== null || state.highlightMayBeActive;
     state.snapshot = snapshot;
+    state.runtimeState.inspectGeneration++;
     state.componentPropertyEdit.error = null;
     state.snapshotGeneration++;
     if (state.highlightTimer) window.clearTimeout(state.highlightTimer);
@@ -975,9 +1041,14 @@ async function refreshSnapshotInternal(componentPropertyEditOperationGeneration)
       state.selectedNodeId = nodeId(chooseInitialNode(snapshot.tree));
       revealPath(state.selectedNodeId);
     }
+    if (state.selectedNodeId !== previousSelectedNodeId) {
+      resetRuntimeStateForSelectionChange(state.selectedNodeId);
+    }
     render();
+    return SNAPSHOT_REFRESH_APPLIED;
   } catch (error) {
     if (requestIsCurrent()) reportError(error);
+    return SNAPSHOT_REFRESH_SKIPPED;
   } finally {
     if (state.snapshotRequestCompletion === requestCompletion) {
       state.snapshotRequestCompletion = null;
@@ -994,7 +1065,8 @@ function startRefreshTimer() {
     if (isDirectMode()) void refreshTargetRegistry();
     if (!state.autoRefresh) return;
     if (state.componentPropertyEdit.focused || state.componentPropertyEdit.pending) return;
-    if (state.activeSection === 'elements') void refreshSnapshot();
+    if (runtimeStatePresentationHasFocus()) return;
+    if (state.activeSection === 'elements' || state.activeSection === 'state') void refreshSnapshot();
     if (state.activeSection === 'performance') void refreshPerformance({ silent: true });
   }, 1200);
 }
@@ -1098,6 +1170,621 @@ function propertyRows(attributes, options) {
         `<div class="property-row"><span class="property-name">${escapeHtml(key)}</span>: ${renderValue(value)}${options.css ? ';' : ''}</div>`,
     )
     .join('');
+}
+
+function runtimeStateParseError(message) {
+  return new Error(`Runtime state ${message}.`);
+}
+
+function runtimeStateKeywordAt(source, offset, keyword) {
+  return source.startsWith(keyword, offset) && !/[A-Za-z0-9_$]/.test(source[offset + keyword.length] || '');
+}
+
+function readRuntimeStateToken(source, parser) {
+  while (parser.offset < source.length && /[\t\n\r ]/.test(source[parser.offset])) parser.offset++;
+  if (parser.offset >= source.length) return { type: 'end' };
+  parser.tokens++;
+  if (parser.tokens > MAX_RUNTIME_STATE_TOKENS) throw runtimeStateParseError('exceeds the token limit');
+  if (parser.sourceType !== RUNTIME_STATE_SOURCE_WEB) {
+    throw runtimeStateParseError('cannot structurally parse a native snapshot');
+  }
+
+  const character = source[parser.offset];
+  if ('{}[]:,'.includes(character)) {
+    parser.offset++;
+    return { type: 'punctuation', value: character };
+  }
+  if (character === '"') {
+    const start = parser.offset;
+    parser.offset++;
+    let closed = false;
+    while (parser.offset < source.length) {
+      const code = source.charCodeAt(parser.offset);
+      if (code < 0x20) throw runtimeStateParseError('contains an invalid string');
+      if (source[parser.offset] === '"') {
+        parser.offset++;
+        closed = true;
+        break;
+      }
+      if (source[parser.offset] !== '\\') {
+        parser.offset++;
+        continue;
+      }
+      parser.offset++;
+      const escape = source[parser.offset];
+      if ('"\\/bfnrt'.includes(escape)) {
+        parser.offset++;
+        continue;
+      }
+      if (escape !== 'u' || !/^[0-9a-fA-F]{4}$/.test(source.slice(parser.offset + 1, parser.offset + 5))) {
+        throw runtimeStateParseError('contains an invalid string escape');
+      }
+      parser.offset += 5;
+    }
+    if (!closed) throw runtimeStateParseError('contains an unterminated string');
+    let value;
+    try {
+      value = JSON.parse(source.slice(start, parser.offset));
+    } catch (_error) {
+      throw runtimeStateParseError('contains an invalid string');
+    }
+    return { type: 'string', value };
+  }
+  if (runtimeStateKeywordAt(source, parser.offset, 'true')) {
+    parser.offset += 4;
+    return { type: 'value', value: true };
+  }
+  if (runtimeStateKeywordAt(source, parser.offset, 'false')) {
+    parser.offset += 5;
+    return { type: 'value', value: false };
+  }
+  if (runtimeStateKeywordAt(source, parser.offset, 'null')) {
+    parser.offset += 4;
+    return { type: 'value', value: null };
+  }
+
+  const start = parser.offset;
+  if (source[parser.offset] === '-') parser.offset++;
+  if (source[parser.offset] === '0') {
+    parser.offset++;
+    if (/\d/.test(source[parser.offset] || '')) throw runtimeStateParseError('contains an invalid number');
+  } else if (/[1-9]/.test(source[parser.offset] || '')) {
+    while (/\d/.test(source[parser.offset] || '')) parser.offset++;
+  } else {
+    throw runtimeStateParseError('contains an unsupported token');
+  }
+  if (source[parser.offset] === '.') {
+    parser.offset++;
+    if (!/\d/.test(source[parser.offset] || '')) throw runtimeStateParseError('contains an invalid number');
+    while (/\d/.test(source[parser.offset] || '')) parser.offset++;
+  }
+  if (source[parser.offset] === 'e' || source[parser.offset] === 'E') {
+    parser.offset++;
+    if (source[parser.offset] === '+' || source[parser.offset] === '-') parser.offset++;
+    if (!/\d/.test(source[parser.offset] || '')) throw runtimeStateParseError('contains an invalid number');
+    while (/\d/.test(source[parser.offset] || '')) parser.offset++;
+  }
+  const value = Number(source.slice(start, parser.offset));
+  if (!Number.isFinite(value)) throw runtimeStateParseError('contains a non-finite number');
+  return { type: 'value', value };
+}
+
+function parseRuntimeState(source, sourceType) {
+  if (typeof source !== 'string') {
+    return { error: 'Runtime state is not a serialized document.', parsed: false, value: null };
+  }
+  if (source.length === 0 || source.length > MAX_RUNTIME_STATE_CHARACTERS) {
+    return {
+      error: `Runtime state must contain between 1 and ${MAX_RUNTIME_STATE_CHARACTERS} characters.`,
+      parsed: false,
+      value: null,
+    };
+  }
+  if (sourceType !== RUNTIME_STATE_SOURCE_NATIVE && sourceType !== RUNTIME_STATE_SOURCE_WEB) {
+    return { error: 'Runtime state has an unknown snapshot source.', parsed: false, value: null };
+  }
+  if (sourceType === RUNTIME_STATE_SOURCE_NATIVE) {
+    return {
+      error: 'Native runtime state is displayed as escaped raw text.',
+      parsed: false,
+      value: null,
+    };
+  }
+
+  const parser = { offset: 0, sourceType, tokens: 0 };
+  const stack = [];
+  let root;
+  let rootSet = false;
+
+  const setValue = value => {
+    if (stack.length === 0) {
+      if (rootSet) throw runtimeStateParseError('contains trailing data');
+      root = value;
+      rootSet = true;
+      return;
+    }
+    const frame = stack[stack.length - 1];
+    if (frame.type === 'array') {
+      if (frame.stage !== 'initialOrEnd' && frame.stage !== 'value') {
+        throw runtimeStateParseError('contains an unexpected array value');
+      }
+      if (frame.entries >= MAX_RUNTIME_STATE_CONTAINER_ENTRIES) {
+        throw runtimeStateParseError('exceeds the per-container entry limit');
+      }
+      frame.values.push(value);
+      frame.entries++;
+      frame.stage = 'commaOrEnd';
+      return;
+    }
+    if (frame.stage !== 'value' || frame.key === null) {
+      throw runtimeStateParseError('contains an unexpected object value');
+    }
+    if (frame.entries >= MAX_RUNTIME_STATE_CONTAINER_ENTRIES) {
+      throw runtimeStateParseError('exceeds the per-container entry limit');
+    }
+    if (Object.prototype.hasOwnProperty.call(frame.target, frame.key)) {
+      throw runtimeStateParseError('contains a duplicate object key');
+    }
+    Object.defineProperty(frame.target, frame.key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
+    frame.entries++;
+    frame.key = null;
+    frame.stage = 'commaOrEnd';
+  };
+
+  const beginContainer = type => {
+    if (stack.length >= MAX_RUNTIME_STATE_DEPTH) throw runtimeStateParseError('exceeds the depth limit');
+    const target = type === 'array' ? [] : Object.create(null);
+    setValue(target);
+    stack.push({ entries: 0, key: null, stage: 'initialOrEnd', target, type, values: target });
+  };
+
+  const acceptValueToken = token => {
+    if (token.type === 'value' || token.type === 'string') {
+      setValue(token.value);
+      return true;
+    }
+    if (token.type === 'punctuation' && token.value === '{') {
+      beginContainer('object');
+      return true;
+    }
+    if (token.type === 'punctuation' && token.value === '[') {
+      beginContainer('array');
+      return true;
+    }
+    return false;
+  };
+
+  try {
+    while (true) {
+      const token = readRuntimeStateToken(source, parser);
+      if (token.type === 'end') {
+        if (!rootSet) throw runtimeStateParseError('is empty');
+        if (stack.length > 0) throw runtimeStateParseError('contains an unterminated container');
+        return { error: null, parsed: true, value: root };
+      }
+      if (stack.length === 0) {
+        if (rootSet || !acceptValueToken(token)) throw runtimeStateParseError('contains trailing data');
+        continue;
+      }
+
+      const frame = stack[stack.length - 1];
+      if (frame.type === 'object') {
+        if (frame.stage === 'initialOrEnd' || frame.stage === 'key') {
+          if (token.type === 'punctuation' && token.value === '}' && frame.stage === 'initialOrEnd') {
+            stack.pop();
+            continue;
+          }
+          if (token.type !== 'string') {
+            throw runtimeStateParseError('contains an invalid object key');
+          }
+          if (token.value.length > MAX_RUNTIME_STATE_KEY_CHARACTERS) {
+            throw runtimeStateParseError('contains an overlong object key');
+          }
+          frame.key = token.value;
+          frame.stage = 'colon';
+          continue;
+        }
+        if (frame.stage === 'colon') {
+          if (token.type !== 'punctuation' || token.value !== ':') {
+            throw runtimeStateParseError('is missing an object value separator');
+          }
+          frame.stage = 'value';
+          continue;
+        }
+        if (frame.stage === 'value') {
+          if (!acceptValueToken(token)) throw runtimeStateParseError('contains an invalid object value');
+          continue;
+        }
+        if (token.type === 'punctuation' && token.value === ',') {
+          frame.stage = 'key';
+          continue;
+        }
+        if (token.type === 'punctuation' && token.value === '}') {
+          stack.pop();
+          continue;
+        }
+        throw runtimeStateParseError('contains an invalid object separator');
+      }
+
+      if (frame.stage === 'initialOrEnd') {
+        if (token.type === 'punctuation' && token.value === ']') {
+          stack.pop();
+          continue;
+        }
+        if (!acceptValueToken(token)) throw runtimeStateParseError('contains an invalid array value');
+        continue;
+      }
+      if (frame.stage === 'value') {
+        if (!acceptValueToken(token)) throw runtimeStateParseError('contains an invalid array value');
+        continue;
+      }
+      if (token.type === 'punctuation' && token.value === ',') {
+        frame.stage = 'value';
+        continue;
+      }
+      if (token.type === 'punctuation' && token.value === ']') {
+        stack.pop();
+        continue;
+      }
+      throw runtimeStateParseError('contains an invalid array separator');
+    }
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : 'Runtime state could not be parsed.',
+      parsed: false,
+      value: null,
+    };
+  }
+}
+
+function runtimeStateOwnDataValue(source, propertyName) {
+  if (typeof source !== 'object' || source === null) return null;
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(source, propertyName);
+    if (descriptor?.enumerable !== true || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      return null;
+    }
+    return { value: descriptor.value };
+  } catch (_error) {
+    return null;
+  }
+}
+
+function runtimeStateExactNodeId(value) {
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (Number.isSafeInteger(value) && value >= 0) return String(value);
+  return null;
+}
+
+function runtimeStateSelectableNodeId(node) {
+  if (typeof node !== 'object' || node === null) return null;
+  try {
+    const nodeIdDescriptor = Object.getOwnPropertyDescriptor(node, 'id');
+    if (nodeIdDescriptor !== undefined) {
+      if (nodeIdDescriptor.enumerable !== true || !Object.prototype.hasOwnProperty.call(nodeIdDescriptor, 'value')) {
+        return null;
+      }
+      return runtimeStateExactNodeId(nodeIdDescriptor.value);
+    }
+  } catch (_error) {
+    return null;
+  }
+  const elementValue = runtimeStateOwnDataValue(node, 'element')?.value;
+  return runtimeStateExactNodeId(runtimeStateOwnDataValue(elementValue, 'id')?.value);
+}
+
+function runtimeStateSourceType() {
+  return launchIdentity.mode === 'inspected-page' ? RUNTIME_STATE_SOURCE_WEB : RUNTIME_STATE_SOURCE_NATIVE;
+}
+
+function runtimeStateComponentRecord(node, structuralId) {
+  const componentValue = runtimeStateOwnDataValue(node, 'component')?.value;
+  const stateValue = runtimeStateOwnDataValue(componentValue, 'state')?.value;
+  if (typeof stateValue !== 'string' || stateValue.length === 0 || stateValue.length > MAX_RUNTIME_STATE_CHARACTERS) {
+    return null;
+  }
+  const sourceType = runtimeStateSourceType();
+  const nameValue = runtimeStateOwnDataValue(componentValue, 'name')?.value;
+  const componentKeyValue = runtimeStateOwnDataValue(componentValue, 'key')?.value;
+  const nodeKeyValue = runtimeStateOwnDataValue(node, 'key')?.value;
+  const keyValue = sourceType === RUNTIME_STATE_SOURCE_WEB ? componentKeyValue : nodeKeyValue;
+  const tagValue = runtimeStateOwnDataValue(node, 'tag')?.value;
+  return {
+    key: typeof keyValue === 'string' ? keyValue : '',
+    name:
+      typeof nameValue === 'string' && nameValue.length > 0
+        ? nameValue
+        : typeof tagValue === 'string' && tagValue.length > 0
+          ? tagValue
+          : 'Component',
+    node,
+    selectableNodeId: runtimeStateSelectableNodeId(node),
+    source: stateValue,
+    sourceType,
+    structuralId,
+  };
+}
+
+function collectRuntimeStateComponents(root) {
+  const exactSelectableNodes = new Map();
+  const records = [];
+  const structuralPaths = new WeakMap();
+  let truncated = false;
+  walk(root, (node, ancestors, _depth, sourceChildIndex) => {
+    let structuralPath;
+    if (ancestors.length === 0) {
+      structuralPath = [];
+    } else {
+      const parentPath = structuralPaths.get(ancestors[ancestors.length - 1]);
+      if (!Array.isArray(parentPath) || !Number.isSafeInteger(sourceChildIndex) || sourceChildIndex < 0) {
+        return false;
+      }
+      structuralPath = [...parentPath, sourceChildIndex];
+    }
+    structuralPaths.set(node, structuralPath);
+    const selectableNodeId = runtimeStateSelectableNodeId(node);
+    if (selectableNodeId !== null) {
+      if (exactSelectableNodes.has(selectableNodeId)) exactSelectableNodes.set(selectableNodeId, null);
+      else exactSelectableNodes.set(selectableNodeId, node);
+    }
+    const record = runtimeStateComponentRecord(node, JSON.stringify(structuralPath));
+    if (record === null) return true;
+    if (records.length >= MAX_RUNTIME_STATE_COMPONENT_ROWS) {
+      truncated = true;
+      return true;
+    }
+    records.push(record);
+    return true;
+  });
+  for (const record of records) {
+    if (record.selectableNodeId !== null && exactSelectableNodes.get(record.selectableNodeId) !== record.node) {
+      record.selectableNodeId = null;
+    }
+  }
+  return { records, truncated };
+}
+
+function findRuntimeStateRecordByStructuralId(structuralId) {
+  return (
+    collectRuntimeStateComponents(state.snapshot?.tree).records.find(record => record.structuralId === structuralId) ||
+    null
+  );
+}
+
+function runtimeStateContainerEntries(value) {
+  if (Array.isArray(value)) return value.map((entry, index) => [String(index), entry]);
+  if (typeof value !== 'object' || value === null) return [];
+  return Object.keys(value).map(key => [key, Object.getOwnPropertyDescriptor(value, key)?.value]);
+}
+
+function runtimeStateDescription(value) {
+  if (Array.isArray(value)) return `${value.length} item${value.length === 1 ? '' : 's'}`;
+  if (typeof value === 'object' && value !== null) {
+    const count = Object.keys(value).length;
+    return `${count} field${count === 1 ? '' : 's'}`;
+  }
+  return typeof value;
+}
+
+function renderRuntimeStatePrimitive(value) {
+  if (value === null) return '<span class="runtime-state-value-null">null</span>';
+  const type = typeof value;
+  const serialized = type === 'string' ? JSON.stringify(value) : String(value);
+  return `<span class="runtime-state-value-${escapeHtml(type)}">${escapeHtml(serialized)}</span>`;
+}
+
+function runtimeStateValuePath(scope, componentId, segments) {
+  return JSON.stringify([scope, componentId, ...segments]);
+}
+
+function renderRuntimeStateEntries(value, context, segments) {
+  const entries = runtimeStateContainerEntries(value);
+  if (entries.length === 0) return '<div class="empty-state">This state container is empty.</div>';
+  const rows = [];
+  for (const [key, entryValue] of entries) {
+    if (context.rows >= MAX_RUNTIME_STATE_VALUE_ROWS) {
+      context.truncated = true;
+      break;
+    }
+    context.rows++;
+    const entrySegments = [...segments, key];
+    const keyLabel = Array.isArray(value) ? `[${key}]` : key;
+    if (typeof entryValue !== 'object' || entryValue === null) {
+      rows.push(
+        `<div class="runtime-state-value-row"><span class="runtime-state-value-key">${escapeHtml(keyLabel)}</span>: ${renderRuntimeStatePrimitive(entryValue)}</div>`,
+      );
+      continue;
+    }
+    const path = runtimeStateValuePath(context.scope, context.componentId, entrySegments);
+    const expanded = context.expandedPaths.has(path);
+    rows.push(`
+      <details class="runtime-state-value-details" data-runtime-state-value-path="${escapeHtml(path)}" data-runtime-state-value-scope="${escapeHtml(context.scope)}"${expanded ? ' open' : ''}>
+        <summary class="runtime-state-value-summary"><span class="runtime-state-disclosure">›</span><span class="runtime-state-value-key">${escapeHtml(keyLabel)}</span>: <span class="runtime-state-value-description">${escapeHtml(runtimeStateDescription(entryValue))}</span></summary>
+        ${expanded ? `<div class="runtime-state-value-children">${renderRuntimeStateEntries(entryValue, context, entrySegments)}</div>` : ''}
+      </details>
+    `);
+  }
+  if (context.truncated && !context.limitRendered) {
+    context.limitRendered = true;
+    rows.push('<div class="runtime-state-limit">Additional state rows were omitted.</div>');
+  }
+  return rows.join('');
+}
+
+function renderRuntimeStateDocument(record, parsed, context) {
+  if (!parsed.parsed || typeof parsed.value !== 'object' || parsed.value === null) {
+    return `<div class="runtime-state-limit">${escapeHtml(parsed.error || 'Runtime state is not an object document.')}</div><pre class="runtime-state-raw">${escapeHtml(record.source)}</pre>`;
+  }
+  return renderRuntimeStateEntries(parsed.value, context, []);
+}
+
+function hydrateRuntimeStateInspectButtons(models) {
+  const buttons = elements.stateContent?.querySelectorAll?.('[data-runtime-state-inspect-slot]') || [];
+  for (const button of buttons) {
+    const index = Number(button.dataset.runtimeStateInspectSlot);
+    const model = Number.isSafeInteger(index) && index >= 0 ? models[index] : undefined;
+    if (!model) continue;
+    delete button.dataset.runtimeStateInspectSlot;
+    button.dataset.runtimeStateInspect = '';
+    runtimeStateInspectBindings.set(button, model);
+  }
+}
+
+function renderRuntimeStateSection() {
+  if (!elements.stateContent || !elements.stateSummary) return;
+  const renderGeneration = ++state.runtimeState.inspectGeneration;
+  const snapshotGeneration = state.snapshotGeneration;
+  const collected = collectRuntimeStateComponents(state.snapshot?.tree);
+  const normalizedSearch = state.runtimeState.search.trim().toLowerCase();
+  const records = normalizedSearch
+    ? collected.records.filter(record =>
+        `${record.name} ${record.key} ${record.source}`.toLowerCase().includes(normalizedSearch),
+      )
+    : collected.records;
+  elements.stateSummary.textContent = `${records.length}${normalizedSearch ? ` of ${collected.records.length}` : ''} component${collected.records.length === 1 ? '' : 's'}${collected.truncated ? ' · first 500' : ''}`;
+  if (!state.snapshot?.tree) {
+    elements.stateContent.innerHTML = '<div class="empty-state">Waiting for the inspected component hierarchy…</div>';
+    return;
+  }
+  if (records.length === 0) {
+    elements.stateContent.innerHTML = `<div class="empty-state">${normalizedSearch ? 'No component state matches this filter.' : 'No mounted component has published bounded runtime state.'}</div>`;
+    return;
+  }
+
+  const inspectModels = [];
+  const renderContext = {
+    componentId: '',
+    expandedPaths: state.runtimeState.expandedMainValues,
+    rows: 0,
+    limitRendered: false,
+    scope: 'main',
+    truncated: false,
+  };
+  const markup = records
+    .map(record => {
+      const expanded = state.runtimeState.expandedComponents.has(record.structuralId);
+      const parsed = parseRuntimeState(record.source, record.sourceType);
+      let inspectButton = '';
+      if (record.selectableNodeId !== null) {
+        const inspectIndex =
+          inspectModels.push({
+            generation: renderGeneration,
+            node: record.node,
+            selectableNodeId: record.selectableNodeId,
+            snapshotGeneration,
+            source: record.source,
+            structuralId: record.structuralId,
+          }) - 1;
+        inspectButton = `<button type="button" class="runtime-state-inspect" data-runtime-state-inspect-slot="${inspectIndex}" aria-label="${escapeHtml(`Inspect ${record.name}${record.key ? ` ${record.key}` : ''} state, component ${record.selectableNodeId}`)}">Inspect</button>`;
+      }
+      renderContext.componentId = record.structuralId;
+      const description = parsed.parsed ? runtimeStateDescription(parsed.value) : 'bounded raw snapshot';
+      const body = expanded
+        ? `<div class="runtime-state-component-body">${renderRuntimeStateDocument(record, parsed, renderContext)}</div>`
+        : '';
+      return `
+        <div class="runtime-state-component">
+          <details class="runtime-state-component-details" data-runtime-state-component-id="${escapeHtml(record.structuralId)}"${expanded ? ' open' : ''}>
+            <summary class="runtime-state-component-summary"><span class="runtime-state-disclosure">›</span><span class="runtime-state-component-name">${escapeHtml(record.name)}</span>${record.key ? `<span class="runtime-state-component-key">${escapeHtml(record.key)}</span>` : ''}<span class="runtime-state-component-description">${escapeHtml(description)}</span></summary>
+            ${body}
+          </details>
+          ${inspectButton}
+        </div>
+      `;
+    })
+    .join('');
+  elements.stateContent.innerHTML = markup;
+  hydrateRuntimeStateInspectButtons(inspectModels);
+}
+
+function renderSelectedRuntimeState(node) {
+  resetRuntimeStateForSelectionChange(nodeId(node));
+  const record = runtimeStateComponentRecord(node, JSON.stringify(['selected']));
+  if (record === null) {
+    return '<div class="empty-state">This selected component has no bounded runtime state snapshot.</div>';
+  }
+  const parsed = parseRuntimeState(record.source, record.sourceType);
+  const context = {
+    componentId: record.structuralId,
+    expandedPaths: state.runtimeState.expandedInspectorValues,
+    rows: 0,
+    limitRendered: false,
+    scope: 'inspector',
+    truncated: false,
+  };
+  return `<section class="runtime-state-inspector"><div class="rule-header">Component state <span class="rule-origin">${escapeHtml(record.name)}</span></div>${renderRuntimeStateDocument(record, parsed, context)}</section>`;
+}
+
+function inspectRuntimeStateBinding(binding) {
+  if (
+    binding?.generation !== state.runtimeState.inspectGeneration ||
+    binding.snapshotGeneration !== state.snapshotGeneration
+  ) {
+    return false;
+  }
+  const currentRecord = findRuntimeStateRecordByStructuralId(binding.structuralId);
+  if (
+    currentRecord?.node !== binding.node ||
+    currentRecord.selectableNodeId !== binding.selectableNodeId ||
+    currentRecord.source !== binding.source
+  ) {
+    return false;
+  }
+  setActiveSection('elements');
+  selectNode(binding.selectableNodeId);
+  setActiveDetail('state');
+  elements.detailTabs.find(tab => tab.dataset.detail === 'state')?.focus?.({ preventScroll: true });
+  return true;
+}
+
+function restoreRuntimeStateDisclosureFocus(scope, componentId, valuePath) {
+  const container = scope === 'inspector' ? elements.inspector : elements.stateContent;
+  const detailsElements = container?.querySelectorAll?.('details') || [];
+  for (const candidate of detailsElements) {
+    if (
+      (componentId !== null && candidate.dataset.runtimeStateComponentId === componentId) ||
+      (valuePath !== null && candidate.dataset.runtimeStateValuePath === valuePath)
+    ) {
+      candidate.querySelector?.('summary')?.focus?.({ preventScroll: true });
+      return;
+    }
+  }
+}
+
+function updateRuntimeStateDisclosure(details) {
+  if (!details?.dataset) return;
+  const valuePath = details.dataset.runtimeStateValuePath;
+  if (valuePath) {
+    const summary = details.querySelector?.('summary');
+    const restoreFocus = summary !== null && summary !== undefined && summary === document.activeElement;
+    const scope = details.dataset.runtimeStateValueScope === 'inspector' ? 'inspector' : 'main';
+    const expandedPaths =
+      scope === 'inspector' ? state.runtimeState.expandedInspectorValues : state.runtimeState.expandedMainValues;
+    if (details.open === expandedPaths.has(valuePath)) return;
+    if (details.open) expandedPaths.add(valuePath);
+    else expandedPaths.delete(valuePath);
+    if (scope === 'inspector') renderInspector();
+    else renderRuntimeStateSection();
+    if (restoreFocus) restoreRuntimeStateDisclosureFocus(scope, null, valuePath);
+    return;
+  }
+  const structuralId = details.dataset.runtimeStateComponentId;
+  if (!structuralId) return;
+  const summary = details.querySelector?.('summary');
+  const restoreFocus = summary !== null && summary !== undefined && summary === document.activeElement;
+  const expanded = state.runtimeState.expandedComponents.has(structuralId);
+  if (details.open === expanded) return;
+  const record = findRuntimeStateRecordByStructuralId(structuralId);
+  if (details.open && record === null) return;
+  if (details.open) state.runtimeState.expandedComponents.add(structuralId);
+  else state.runtimeState.expandedComponents.delete(structuralId);
+  renderRuntimeStateSection();
+  if (restoreFocus) restoreRuntimeStateDisclosureFocus('main', structuralId, null);
 }
 
 function componentPropertyEditMetadata(node, propertyName, value) {
@@ -1279,6 +1966,7 @@ async function submitComponentPropertyEdit(componentId, propertyName, componentT
   renderInspector();
   let updated = false;
   let refreshed = false;
+  let refreshDeferredForRuntimeState = false;
   try {
     const result = await requestJson(
       '/api/devtools/component-property',
@@ -1297,9 +1985,9 @@ async function submitComponentPropertyEdit(componentId, propertyName, componentT
     if (requestIsCurrent()) {
       updated = result.updated === true;
       if (updated) {
-        const previousSnapshotGeneration = state.snapshotGeneration;
-        await refreshSnapshotInternal(operationGeneration);
-        refreshed = state.snapshotGeneration !== previousSnapshotGeneration;
+        const refreshOutcome = await refreshSnapshotInternal(operationGeneration);
+        refreshed = refreshOutcome === SNAPSHOT_REFRESH_APPLIED;
+        refreshDeferredForRuntimeState = refreshOutcome === SNAPSHOT_REFRESH_RUNTIME_STATE_DEFERRED;
       }
     }
   } catch (error) {
@@ -1310,10 +1998,10 @@ async function submitComponentPropertyEdit(componentId, propertyName, componentT
     if (operationIsCurrent()) {
       state.componentPropertyEdit.pending = false;
       state.componentPropertyEdit.focused = false;
-      if (updated && !refreshed && state.componentPropertyEdit.error === null) {
+      if (updated && !refreshed && !refreshDeferredForRuntimeState && state.componentPropertyEdit.error === null) {
         state.componentPropertyEdit.error = COMPONENT_PROPERTY_EDIT_ERROR;
       }
-      renderInspector();
+      if (!runtimeStatePresentationHasFocus()) renderInspector();
     }
   }
 }
@@ -1437,11 +2125,15 @@ function renderInspector() {
 
   const renderedNode = inspectedNode(node);
   const componentPropertyEditorModels = [];
-  const componentProperties = renderComponentProperties(node, componentPropertyEditorModels);
   const renderMarkup = markup => {
     elements.inspector.innerHTML = markup;
     hydrateComponentPropertyEditors(componentPropertyEditorModels);
   };
+  if (state.activeDetail === 'state') {
+    renderMarkup(renderSelectedRuntimeState(node));
+    return;
+  }
+  const componentProperties = renderComponentProperties(node, componentPropertyEditorModels);
   if (node.component && renderedNode === node) {
     renderMarkup(
       `<div class="rule-header">Valdi component <span class="rule-origin">${escapeHtml(node.tag)}</span></div>${propertyRows(componentMetadata(node), { css: false })}${componentProperties}<div class="empty-state">This component does not currently render a backing element.</div>`,
@@ -1481,12 +2173,15 @@ function render() {
   renderTree();
   renderInspector();
   renderBreadcrumbs();
+  if (state.activeSection === 'state') renderRuntimeStateSection();
 }
 
 function selectNode(id) {
   const node = findNode(id);
   if (!node) return;
-  state.selectedNodeId = nodeId(node);
+  const selectedNodeId = nodeId(node);
+  resetRuntimeStateForSelectionChange(selectedNodeId);
+  state.selectedNodeId = selectedNodeId;
   revealPath(state.selectedNodeId);
   render();
 }
@@ -2200,6 +2895,10 @@ function setActiveSection(section) {
   }
   if (activeSection === 'console') elements.consoleInput.focus();
   if (activeSection === 'elements') void refreshSnapshot();
+  if (activeSection === 'state') {
+    renderRuntimeStateSection();
+    void refreshSnapshot();
+  }
   if (activeSection === 'performance') {
     renderPerformance();
     void refreshPerformance();
@@ -2229,8 +2928,27 @@ function setActiveDetail(detail) {
     const selected = tab.dataset.detail === detail;
     tab.classList.toggle('selected', selected);
     tab.setAttribute('aria-selected', String(selected));
+    tab.tabIndex = selected ? 0 : -1;
+    if (selected && tab.id) elements.inspector.setAttribute('aria-labelledby', tab.id);
   }
   renderInspector();
+}
+
+function handleDetailTabNavigation(event) {
+  if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+  const tabs = elements.detailTabs.filter(tab => !tab.disabled);
+  if (!tabs.length) return;
+  event.preventDefault();
+  const currentIndex = Math.max(0, tabs.indexOf(event.currentTarget));
+  const nextIndex =
+    event.key === 'Home'
+      ? 0
+      : event.key === 'End'
+        ? tabs.length - 1
+        : (currentIndex + (event.key === 'ArrowRight' ? 1 : -1) + tabs.length) % tabs.length;
+  const nextTab = tabs[nextIndex];
+  setActiveDetail(nextTab.dataset.detail);
+  nextTab.focus();
 }
 
 function stopConsoleStream() {
@@ -2384,6 +3102,7 @@ function wireEvents() {
   }
   for (const tab of elements.detailTabs) {
     tab.addEventListener('click', () => setActiveDetail(tab.dataset.detail));
+    tab.addEventListener('keydown', handleDetailTabNavigation);
   }
   elements.targetSelect.addEventListener('change', () => {
     if (!isDirectMode()) return;
@@ -2456,6 +3175,18 @@ function wireEvents() {
     state.search = elements.treeFilter.value;
     renderTree();
   });
+  elements.stateFilter.addEventListener('input', () => {
+    state.runtimeState.search = elements.stateFilter.value;
+    renderRuntimeStateSection();
+  });
+  elements.stateContent.addEventListener('click', event => {
+    const button = event.target.closest?.('[data-runtime-state-inspect]');
+    if (!button) return;
+    event.preventDefault();
+    event.stopPropagation();
+    inspectRuntimeStateBinding(runtimeStateInspectBindings.get(button));
+  });
+  elements.stateContent.addEventListener('toggle', event => updateRuntimeStateDisclosure(event.target), true);
   elements.expandButton.addEventListener('click', () => {
     expandUsefulNodes(state.snapshot?.tree);
     if (state.selectedNodeId) revealPath(state.selectedNodeId);
@@ -2525,6 +3256,7 @@ function wireEvents() {
       value,
     );
   });
+  elements.inspector.addEventListener('toggle', event => updateRuntimeStateDisclosure(event.target), true);
   elements.breadcrumbs.addEventListener('click', event => {
     const button = event.target.closest('[data-breadcrumb-id]');
     if (button) selectNode(button.dataset.breadcrumbId);
@@ -2571,7 +3303,9 @@ function wireEvents() {
   });
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden && isDirectMode()) void refreshTargetRegistry();
-    if (!document.hidden && state.activeSection === 'elements') void refreshSnapshot();
+    if (!document.hidden && (state.activeSection === 'elements' || state.activeSection === 'state')) {
+      void refreshSnapshot();
+    }
     if (!document.hidden && state.activeSection === 'performance') void refreshPerformance({ silent: true });
   });
 }

--- a/npm_modules/cli/src/debugger/devtoolsPanel.spec.ts
+++ b/npm_modules/cli/src/debugger/devtoolsPanel.spec.ts
@@ -12,6 +12,7 @@ interface DevToolsTreeNode {
     name: string;
     properties?: Record<string, unknown>;
     propertyEdits?: Record<string, { componentToken: string; snapshotRevision: number }>;
+    state?: string;
   };
   element?: {
     attributes: Record<string, unknown>;
@@ -145,7 +146,7 @@ interface PickerStubElement {
   addEventListener(type: string, listener: (event: PickerStubEvent) => void): void;
   append(child: PickerStubElement): void;
   closest(selector: string): PickerStubElement | null;
-  contains(): boolean;
+  contains(element?: PickerStubElement): boolean;
   dispatch(type: string, properties?: Partial<PickerStubEvent>): void;
   focus(): void;
   getAttribute(name: string): string | null;
@@ -161,6 +162,7 @@ interface PickerStubElement {
 
 interface PickerPanel {
   state: {
+    activeDetail: string;
     activeSection: string;
     consoleEntries: Array<{ kind: string; value: string }>;
     consoleEntryKeys: Set<string>;
@@ -473,12 +475,12 @@ function createPickerHarness(search: string): PickerHarness {
     return element;
   }
 
-  const mainTabs = ['elements', 'performance', 'console'].map(section => {
+  const mainTabs = ['elements', 'state', 'performance', 'console'].map(section => {
     const tab = elementForId(`${section}Tab`);
     tab.dataset['section'] = section;
     return tab;
   });
-  const sections = ['elements', 'performance', 'console'].map(section => {
+  const sections = ['elements', 'state', 'performance', 'console'].map(section => {
     const panelElement = elementForId(`${section}Section`);
     panelElement.dataset['panel'] = section;
     return panelElement;
@@ -1507,6 +1509,70 @@ describe('integrated DevTools capability-aware target picker', () => {
     });
   });
 
+  it('defers an edit-owned snapshot while either State surface owns focus', async () => {
+    for (const focusScope of ['main', 'inspector'] as const) {
+      const harness = createPickerHarness(
+        '?inspectedUrl=http%3A%2F%2F127.0.0.1%3A54321%2Findex.html%3FvaldiDevTools%3D1&targetNonce=panel-target-nonce-123456',
+      );
+      harness.panel.state.target = pickerTarget('owl:web-preview', {
+        capabilities: ['components', 'component-properties', 'component-property-edit', 'snapshot'],
+        identityMode: 'inspected-page',
+        platform: 'web',
+        sessionId: 'web-preview',
+        state: 'attached',
+        transport: 'web-preview',
+      });
+      harness.panel.state.snapshot = { tree: editableComponentTree(true, 'a'.repeat(32), 7) };
+      harness.panel.state.snapshotGeneration = 7;
+      harness.panel.state.selectedNodeId = 'component:["7","nested"]';
+      const editResponse = harness.queueDeferred('/api/devtools/component-property');
+      const edit = harness.panel.submitComponentPropertyEdit(
+        'component:["7","nested"]',
+        'enabled',
+        'a'.repeat(32),
+        7,
+        false,
+      );
+      await flushPickerPromises();
+      expect(harness.panel.state.componentPropertyEdit.pending).withContext(focusScope).toBeTrue();
+
+      const focusedControl = createPickerStubElement(`${focusScope}-state-control`);
+      const stateSection = requiredPickerElement(harness, 'stateSection');
+      const inspector = requiredPickerElement(harness, 'inspector');
+      stateSection.contains = () => focusScope === 'main';
+      inspector.contains = () => focusScope === 'inspector';
+      harness.panel.state.activeDetail = focusScope === 'inspector' ? 'state' : 'styles';
+      harness.setActiveElement(focusedControl);
+      const focusedMarkup = `focused-${focusScope}-state`;
+      inspector.innerHTML = focusedMarkup;
+
+      editResponse.resolve({ updated: true });
+      await edit;
+
+      expect(harness.fetchRequests.filter(request => new URL(request.url).pathname === '/api/devtools/snapshot').length)
+        .withContext(focusScope)
+        .toBe(0);
+      expect(harness.panel.state.componentPropertyEdit.pending).withContext(focusScope).toBeFalse();
+      expect(harness.panel.state.componentPropertyEdit.error).withContext(focusScope).toBeNull();
+      expect(harness.panel.state.snapshotGeneration).withContext(focusScope).toBe(7);
+      expect(inspector.innerHTML).withContext(focusScope).toBe(focusedMarkup);
+
+      harness.setActiveElement(null);
+      harness.queueResponse('/api/devtools/snapshot', {
+        tree: editableComponentTree(false, 'b'.repeat(32), 8),
+      });
+      await harness.panel.refreshSnapshot();
+
+      expect(harness.panel.state.snapshotGeneration).withContext(focusScope).toBe(8);
+      expect(
+        harness.panel.state.snapshot?.tree.children[0]?.children[0]?.component?.propertyEdits?.['enabled']
+          ?.snapshotRevision,
+      )
+        .withContext(focusScope)
+        .toBe(8);
+    }
+  });
+
   it('rejects an empty numeric editor value through the form submit path', () => {
     const harness = createPickerHarness(
       '?inspectedUrl=http%3A%2F%2F127.0.0.1%3A54321%2Findex.html%3FvaldiDevTools%3D1&targetNonce=panel-target-nonce-123456',
@@ -2080,19 +2146,22 @@ describe('integrated DevTools capability-aware target picker', () => {
     await flushPickerPromises();
     harness.panel.setActiveSection('elements');
     const elementsTab = requiredPickerElement(harness, 'elementsTab');
+    const stateTab = requiredPickerElement(harness, 'stateTab');
     const performanceTab = requiredPickerElement(harness, 'performanceTab');
     const consoleTab = requiredPickerElement(harness, 'consoleTab');
 
     elementsTab.dispatch('keydown', { key: 'ArrowRight' });
 
     expect(performanceTab.disabled).toBeTrue();
-    expect(harness.panel.state.activeSection).toBe('console');
+    expect(harness.panel.state.activeSection).toBe('state');
     expect(elementsTab.tabIndex).toBe(-1);
-    expect(consoleTab.tabIndex).toBe(0);
-    expect(consoleTab.getAttribute('aria-selected')).toBe('true');
+    expect(stateTab.tabIndex).toBe(0);
+    expect(stateTab.getAttribute('aria-selected')).toBe('true');
     expect(requiredPickerElement(harness, 'elementsSection').hidden).toBeTrue();
-    expect(requiredPickerElement(harness, 'consoleSection').hidden).toBeFalse();
+    expect(requiredPickerElement(harness, 'stateSection').hidden).toBeFalse();
 
+    stateTab.dispatch('keydown', { key: 'ArrowRight' });
+    expect(harness.panel.state.activeSection).toBe('console');
     consoleTab.dispatch('keydown', { key: 'ArrowRight' });
     expect(harness.panel.state.activeSection).toBe('elements');
   });
@@ -2748,7 +2817,8 @@ describe('integrated DevTools performance panel', () => {
 
   it('invalidates an old snapshot without wedging polling when the target changes', async () => {
     let resolveSnapshot:
-      ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void) | undefined;
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
     nextFetchResponse = new Promise(resolve => {
       resolveSnapshot = resolve;
     });
@@ -2772,7 +2842,8 @@ describe('integrated DevTools performance panel', () => {
   it('does not let a delayed pre-start status response overwrite a successful Start', async () => {
     panel.state.performance.data = snapshot;
     let resolveSnapshot:
-      ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void) | undefined;
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
     nextFetchResponse = new Promise(resolve => {
       resolveSnapshot = resolve;
     });
@@ -2791,7 +2862,8 @@ describe('integrated DevTools performance panel', () => {
   it('cleans up a stale successful start without overwriting the replacement target', async () => {
     panel.state.performance.data = snapshot;
     let resolveStart:
-      ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void) | undefined;
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
     nextFetchResponse = new Promise(resolve => {
       resolveStart = resolve;
     });
@@ -2822,7 +2894,8 @@ describe('integrated DevTools performance panel', () => {
   it('retains and surfaces a stale Start owner when exact cleanup fails', async () => {
     panel.state.performance.data = snapshot;
     let resolveStart:
-      ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void) | undefined;
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
     nextFetchResponse = new Promise(resolve => {
       resolveStart = resolve;
     });
@@ -2855,7 +2928,8 @@ describe('integrated DevTools performance panel', () => {
   it('does not replace a newer owner when stale Start cleanup fails', async () => {
     panel.state.performance.data = snapshot;
     let resolveStart:
-      ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void) | undefined;
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
     nextFetchResponse = new Promise(resolve => {
       resolveStart = resolve;
     });
@@ -2894,7 +2968,8 @@ describe('integrated DevTools performance panel', () => {
   it('keeps an in-flight Capture owned for exact recovery after a target change', async () => {
     panel.state.performance.data = snapshot;
     let resolveCapture:
-      ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void) | undefined;
+      | ((response: { ok: boolean; status: number; json(): Promise<Record<string, unknown>> }) => void)
+      | undefined;
     nextFetchResponse = new Promise(resolve => {
       resolveCapture = resolve;
     });

--- a/npm_modules/cli/src/debugger/devtoolsRuntimeState.spec.ts
+++ b/npm_modules/cli/src/debugger/devtoolsRuntimeState.spec.ts
@@ -1,0 +1,916 @@
+import 'jasmine';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Script } from 'node:vm';
+
+interface RuntimeNode {
+  children: RuntimeNode[];
+  component?: {
+    key?: string;
+    name?: string;
+    properties?: Record<string, unknown>;
+    state?: string;
+  };
+  element?: { id?: number | string };
+  id?: string;
+  key?: string;
+  tag: string;
+}
+
+interface RuntimeStateRecord {
+  key: string;
+  name: string;
+  node: RuntimeNode;
+  selectableNodeId: string | null;
+  source: string;
+  sourceType: string;
+  structuralId: string;
+}
+
+interface RuntimeStateContext {
+  componentId: string;
+  expandedPaths: Set<string>;
+  limitRendered: boolean;
+  rows: number;
+  scope: string;
+  truncated: boolean;
+}
+
+interface RuntimeParseResult {
+  error: string | null;
+  parsed: boolean;
+  value: unknown;
+}
+
+interface RuntimePanel {
+  elements: {
+    inspector: StubElement;
+    stateContent: StubElement;
+    stateFilter: StubElement;
+    stateSection: StubElement;
+    stateSummary: StubElement;
+  };
+  state: {
+    activeDetail: string;
+    activeSection: string;
+    autoRefresh: boolean;
+    componentPropertyEdit: { focused: boolean; pending: boolean };
+    runtimeState: {
+      expandedComponents: Set<string>;
+      expandedInspectorValues: Set<string>;
+      expandedMainValues: Set<string>;
+      inspectGeneration: number;
+      inspectorNodeId: string | null;
+      search: string;
+    };
+    selectedNodeId: string | null;
+    snapshot: { tree: RuntimeNode } | null;
+    snapshotGeneration: number;
+    target: RuntimeTarget | null;
+  };
+  clearTargetPresentation(message: string): void;
+  collectRuntimeStateComponents(root: RuntimeNode): { records: RuntimeStateRecord[]; truncated: boolean };
+  connectToInspectedPage(): Promise<void>;
+  handleDetailTabNavigation(event: StubEvent): void;
+  inspectRuntimeStateBinding(binding: Record<string, unknown>): boolean;
+  parseRuntimeState(source: string, sourceType: string): RuntimeParseResult;
+  readRuntimeStateToken(
+    source: string,
+    parser: { offset: number; sourceType: string; tokens: number },
+  ): { type: string; value?: unknown };
+  renderRuntimeStateEntries(value: unknown, context: RuntimeStateContext, segments: string[]): string;
+  renderRuntimeStateSection(): void;
+  refreshSnapshot(): Promise<void>;
+  runtimeStateComponentRecord(node: RuntimeNode, structuralId: string): RuntimeStateRecord | null;
+  resetRuntimeStateForSelectionChange(selectedNodeId: string | null): void;
+  resetRuntimeStateForTargetChange(): void;
+  setActiveDetail(detail: string): void;
+  setActiveSection(section: string): void;
+  startRefreshTimer(): void;
+  updateRuntimeStateDisclosure(details: StubElement): void;
+}
+
+interface RuntimeTarget {
+  applicationUrl?: string;
+  capabilities: string[];
+  debuggingPort?: number;
+  id: string;
+  name?: string;
+  sessionId?: string;
+}
+
+interface StubEvent {
+  currentTarget: StubElement;
+  key: string;
+  target: StubElement;
+  preventDefault(): void;
+  stopPropagation(): void;
+}
+
+class StubElement {
+  readonly attributes = new Map<string, string>();
+  readonly children: StubElement[] = [];
+  readonly classNames = new Set<string>();
+  readonly dataset: Record<string, string> = {};
+  readonly listeners = new Map<string, Array<(event: StubEvent) => void>>();
+  readonly queryResults = new Map<string, StubElement[]>();
+  readonly closestResults = new Map<string, StubElement>();
+  readonly containedElements = new Set<StubElement>();
+  readonly style: Record<string, string> = {};
+  readonly classList = {
+    contains: (name: string): boolean => this.classNames.has(name),
+    toggle: (name: string, enabled?: boolean): void => {
+      if (enabled ?? !this.classNames.has(name)) this.classNames.add(name);
+      else this.classNames.delete(name);
+    },
+  };
+  checked = true;
+  className = '';
+  disabled = false;
+  focusCount = 0;
+  hidden = false;
+  innerHTML = '';
+  open = false;
+  scrollHeight = 0;
+  scrollTop = 0;
+  tabIndex = -1;
+  textContent = '';
+  title = '';
+  value = '';
+  private readonly onFocus: (element: StubElement) => void;
+
+  constructor(
+    readonly id: string,
+    onFocus: (element: StubElement) => void,
+  ) {
+    this.onFocus = onFocus;
+  }
+
+  addEventListener(type: string, listener: (event: StubEvent) => void): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  append(child: StubElement): void {
+    this.children.push(child);
+  }
+
+  closest(selector: string): StubElement | null {
+    return this.closestResults.get(selector) ?? null;
+  }
+
+  contains(element: StubElement): boolean {
+    if (element === this || this.containedElements.has(element)) return true;
+    return Array.from(this.containedElements).some(child => child.contains(element));
+  }
+
+  dispatch(type: string, properties: Partial<StubEvent> = {}): void {
+    const event: StubEvent = {
+      currentTarget: this,
+      key: '',
+      preventDefault() {},
+      stopPropagation() {},
+      target: this,
+      ...properties,
+    };
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  focus(): void {
+    this.focusCount++;
+    this.onFocus(this);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  getBoundingClientRect(): { bottom: number; height: number; left: number; right: number; top: number; width: number } {
+    return { bottom: 600, height: 600, left: 0, right: 800, top: 0, width: 800 };
+  }
+
+  querySelector(selector: string): StubElement | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  querySelectorAll(selector: string): StubElement[] {
+    return this.queryResults.get(selector) ?? [];
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+
+  replaceChildren(...children: StubElement[]): void {
+    this.children.splice(0, this.children.length, ...children);
+  }
+
+  scrollIntoView(): void {}
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  setSelectionRange(): void {}
+}
+
+interface RuntimeHarness {
+  detailTabs: StubElement[];
+  fetchPaths: string[];
+  panel: RuntimePanel;
+  deferNextSnapshot(): void;
+  dispatchDocument(type: string): void;
+  resolveDeferredSnapshot(): void;
+  runIntervals(): void;
+  setActiveElement(element: StubElement | null): void;
+  setDocumentHidden(hidden: boolean): void;
+  setTargetPayload(target: RuntimeTarget): void;
+}
+
+function makeRuntimeNode(index: number, source = `{"value":${index}}`): RuntimeNode {
+  return {
+    children: [],
+    component: { key: `key-${index}`, name: `Component${index}`, state: source },
+    id: `component-${index}`,
+    tag: `Component${index}`,
+  };
+}
+
+function createRuntimeHarness(search = '?targetId=runtime-state-test'): RuntimeHarness {
+  const treeModelSource = fs.readFileSync(path.resolve(process.cwd(), 'debugger', 'debugger-tree-model.js'), 'utf8');
+  const rawPanelSource = fs.readFileSync(path.resolve(process.cwd(), 'debugger', 'devtools-panel.js'), 'utf8');
+  const panelSource = rawPanelSource.replace('void connectToInspectedApplication();', 'void 0;');
+  const elements = new Map<string, StubElement>();
+  const intervals: Array<() => void> = [];
+  const fetchPaths: string[] = [];
+  const documentListeners = new Map<string, Array<() => void>>();
+  const documentDataset: Record<string, string> = {};
+  let activeElement: StubElement | null = null;
+  let deferredSnapshotResolve: (() => void) | null = null;
+  let deferSnapshot = false;
+  let documentHidden = false;
+  let targetPayload: RuntimeTarget = {
+    applicationUrl: 'http://127.0.0.1:54321',
+    capabilities: ['components', 'snapshot'],
+    debuggingPort: 54_321,
+    id: 'new-target',
+    name: 'New target',
+    sessionId: 'new-session',
+  };
+
+  const elementForId = (id: string): StubElement => {
+    let element = elements.get(id);
+    if (element === undefined) {
+      element = new StubElement(id, focused => {
+        activeElement = focused;
+      });
+      elements.set(id, element);
+    }
+    return element;
+  };
+  const mainTabs = ['elements', 'state', 'performance', 'console'].map(section => {
+    const tab = elementForId(`${section}Tab`);
+    tab.dataset['section'] = section;
+    return tab;
+  });
+  const detailTabs = ['styles', 'computed', 'state', 'dom'].map(detail => {
+    const tab = elementForId(`${detail}DetailTab`);
+    tab.dataset['detail'] = detail;
+    return tab;
+  });
+  const sections = ['elements', 'state', 'performance', 'console'].map(section => {
+    const sectionElement = elementForId(`${section}Section`);
+    sectionElement.dataset['panel'] = section;
+    return sectionElement;
+  });
+  elementForId('stateSection').containedElements.add(elementForId('stateFilter'));
+  elementForId('stateSection').containedElements.add(elementForId('stateContent'));
+  const documentObject = {
+    addEventListener(type: string, listener: () => void) {
+      const listeners = documentListeners.get(type) ?? [];
+      listeners.push(listener);
+      documentListeners.set(type, listeners);
+    },
+    createElement(type: string): StubElement {
+      return new StubElement(type, focused => {
+        activeElement = focused;
+      });
+    },
+    documentElement: { dataset: documentDataset },
+    get activeElement(): StubElement | null {
+      return activeElement;
+    },
+    getElementById(id: string): StubElement {
+      return elementForId(id);
+    },
+    get hidden(): boolean {
+      return documentHidden;
+    },
+    querySelectorAll(selector: string): StubElement[] {
+      if (selector === '.main-tab') return mainTabs;
+      if (selector === '.detail-tab') return detailTabs;
+      if (selector === '.section') return sections;
+      return [];
+    },
+  };
+  const windowObject = {
+    addEventListener() {},
+    clearInterval() {},
+    clearTimeout() {},
+    confirm: () => true,
+    location: { origin: 'http://127.0.0.1:18768', search },
+    parent: {},
+    removeEventListener() {},
+    setInterval(callback: () => void): number {
+      intervals.push(callback);
+      return intervals.length;
+    },
+    setTimeout(callback: () => void): number {
+      callback();
+      return 1;
+    },
+  };
+  class StubEventSource {
+    addEventListener(): void {}
+    close(): void {}
+  }
+  const panel = new Script(
+    `${treeModelSource}\n${panelSource}\n({ clearTargetPresentation, collectRuntimeStateComponents, connectToInspectedPage, elements, handleDetailTabNavigation, inspectRuntimeStateBinding, parseRuntimeState, readRuntimeStateToken, refreshSnapshot, renderRuntimeStateEntries, renderRuntimeStateSection, resetRuntimeStateForSelectionChange, resetRuntimeStateForTargetChange, runtimeStateComponentRecord, setActiveDetail, setActiveSection, startRefreshTimer, state, updateRuntimeStateDisclosure })`,
+  ).runInNewContext({
+    Blob,
+    EventSource: StubEventSource,
+    URL,
+    URLSearchParams,
+    console,
+    document: documentObject,
+    fetch: (input: URL | string) => {
+      const url = new URL(input.toString());
+      fetchPaths.push(url.pathname);
+      const payload =
+        url.pathname === '/api/devtools/target'
+          ? { target: targetPayload }
+          : url.pathname === '/api/devtools/snapshot'
+            ? { target: targetPayload, tree: makeRuntimeNode(1) }
+            : {};
+      const response = { json: () => Promise.resolve(payload), ok: true, status: 200 };
+      if (url.pathname === '/api/devtools/snapshot' && deferSnapshot) {
+        deferSnapshot = false;
+        return new Promise(resolve => {
+          deferredSnapshotResolve = () => resolve(response);
+        });
+      }
+      return Promise.resolve(response);
+    },
+    navigator: { clipboard: { writeText: () => Promise.resolve() } },
+    window: windowObject,
+  }) as RuntimePanel;
+
+  return {
+    detailTabs,
+    deferNextSnapshot() {
+      deferSnapshot = true;
+    },
+    dispatchDocument(type) {
+      for (const listener of documentListeners.get(type) ?? []) listener();
+    },
+    fetchPaths,
+    panel,
+    resolveDeferredSnapshot() {
+      deferredSnapshotResolve?.();
+      deferredSnapshotResolve = null;
+    },
+    runIntervals() {
+      for (const callback of intervals) callback();
+    },
+    setActiveElement(element) {
+      activeElement = element;
+    },
+    setDocumentHidden(hidden) {
+      documentHidden = hidden;
+    },
+    setTargetPayload(target) {
+      targetPayload = target;
+    },
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  for (let index = 0; index < 10; index++) await Promise.resolve();
+}
+
+function makeValueContext(): RuntimeStateContext {
+  return {
+    componentId: 'component',
+    expandedPaths: new Set(),
+    limitRendered: false,
+    rows: 0,
+    scope: 'main',
+    truncated: false,
+  };
+}
+
+describe('DevTools bounded runtime state', () => {
+  it('parses strict JSON into null-prototype records without prototype pollution', () => {
+    const { panel } = createRuntimeHarness();
+    const parsed = panel.parseRuntimeState(
+      '{"__proto__":{"polluted":true},"constructor":{"safe":1},"prototype":{"safe":2}}',
+      'web',
+    );
+    const value = parsed.value as Record<string, unknown>;
+    const emptyRecord: Record<string, unknown> = {};
+
+    expect(parsed.parsed).toBeTrue();
+    expect(Object.getPrototypeOf(value)).toBeNull();
+    expect(Object.getPrototypeOf(value['__proto__'] as object)).toBeNull();
+    expect(Object.prototype.hasOwnProperty.call(value, '__proto__')).toBeTrue();
+    expect(Object.prototype.hasOwnProperty.call(value, 'constructor')).toBeTrue();
+    expect(Object.prototype.hasOwnProperty.call(value, 'prototype')).toBeTrue();
+    expect(emptyRecord['polluted']).toBeUndefined();
+  });
+
+  it('treats every native debug document as escaped raw-only input', () => {
+    const { panel } = createRuntimeHarness();
+    const nativeDocuments = [
+      '{ count: 1, ready: true }',
+      // An actual key of `real: 0, forged` is indistinguishable from two fields
+      // because the native debug serializer does not escape property names.
+      '{ real: 0, forged: true }',
+      'Map{first: 1, second: 2}',
+      'Set(true, false)',
+      '<function callback"/>, forged: true/>',
+      '<error "real: 0, forged: true"/>',
+    ];
+    const node = makeRuntimeNode(1);
+    panel.state.snapshot = { tree: node };
+    panel.state.runtimeState.expandedComponents.add('[]');
+
+    for (const source of nativeDocuments) {
+      const parsed = panel.parseRuntimeState(source, 'native');
+      expect(parsed.parsed).withContext(source).toBeFalse();
+      expect(parsed.value).withContext(source).toBeNull();
+      expect(parsed.error).withContext(source).toContain('escaped raw text');
+      node.component = { state: source };
+      panel.renderRuntimeStateSection();
+      expect(panel.elements.stateContent.innerHTML).withContext(source).toContain('class="runtime-state-raw"');
+      expect(panel.elements.stateContent.innerHTML).withContext(source).not.toContain('runtime-state-value-key');
+    }
+
+    node.component = { state: '<error "real: 0, forged: true"/>' };
+    panel.renderRuntimeStateSection();
+
+    expect(panel.elements.stateContent.innerHTML).toContain('class="runtime-state-raw"');
+    expect(panel.elements.stateContent.innerHTML).toContain('&lt;error &quot;real: 0, forged: true&quot;/&gt;');
+    expect(panel.elements.stateContent.innerHTML).not.toContain('runtime-state-value-key');
+  });
+
+  it('keeps web parsing strict', () => {
+    const { panel } = createRuntimeHarness();
+
+    expect(panel.parseRuntimeState('{"same":1,"same":2}', 'web').parsed).toBeFalse();
+    expect(panel.parseRuntimeState('{ value: 1 }', 'web').parsed).toBeFalse();
+    expect(panel.parseRuntimeState('{"value":"safe"}', 'web').parsed).toBeTrue();
+    expect(panel.parseRuntimeState('{"value":"safe"}', 'unknown').parsed).toBeFalse();
+  });
+
+  it('enforces exact raw, depth, entry, key, and token boundaries', () => {
+    const { panel } = createRuntimeHarness();
+    const depth12 = `${'['.repeat(12)}0${']'.repeat(12)}`;
+    const depth13 = `${'['.repeat(13)}0${']'.repeat(13)}`;
+    const entries100 = `{${Array.from({ length: 100 }, (_value, index) => `"k${index}":${index}`).join(',')}}`;
+    const entries101 = `{${Array.from({ length: 101 }, (_value, index) => `"k${index}":${index}`).join(',')}}`;
+    const key1024 = `{${JSON.stringify('k'.repeat(1024))}:1}`;
+    const key1025 = `{${JSON.stringify('k'.repeat(1025))}:1}`;
+    const raw65536 = `"${'x'.repeat(65_534)}"`;
+    const nearTokenLimit = `[${[
+      `[${Array.from({ length: 8 }, () => '0').join(',')}]`,
+      ...Array.from({ length: 99 }, () => `[${Array.from({ length: 9 }, () => '0').join(',')}]`),
+    ].join(',')}]`;
+    const overTokenLimit = `[${Array.from({ length: 100 }, () => `[${Array.from({ length: 9 }, () => '0').join(',')}]`).join(',')}]`;
+
+    expect(panel.parseRuntimeState(depth12, 'web').parsed).toBeTrue();
+    expect(panel.parseRuntimeState(depth13, 'web').parsed).toBeFalse();
+    expect(panel.parseRuntimeState(entries100, 'web').parsed).toBeTrue();
+    expect(panel.parseRuntimeState(entries101, 'web').parsed).toBeFalse();
+    expect(panel.parseRuntimeState(key1024, 'web').parsed).toBeTrue();
+    expect(panel.parseRuntimeState(key1025, 'web').parsed).toBeFalse();
+    expect(raw65536.length).toBe(65_536);
+    expect(panel.parseRuntimeState(raw65536, 'web').parsed).toBeTrue();
+    expect(panel.parseRuntimeState(`${raw65536} `, 'web').parsed).toBeFalse();
+    expect(panel.parseRuntimeState(nearTokenLimit, 'web').parsed).toBeTrue();
+    expect(panel.parseRuntimeState(overTokenLimit, 'web').parsed).toBeFalse();
+  });
+
+  it('allows exactly 2,000 lexical tokens and rejects token 2,001', () => {
+    const { panel } = createRuntimeHarness();
+    const source = Array.from({ length: 2001 }, () => '0').join(' ');
+    const parser = { offset: 0, sourceType: 'web', tokens: 0 };
+
+    for (let index = 0; index < 2000; index++) {
+      expect(panel.readRuntimeStateToken(source, parser).type).toBe('value');
+    }
+    expect(parser.tokens).toBe(2000);
+    expect(() => panel.readRuntimeStateToken(source, parser)).toThrowError(/token limit/);
+  });
+
+  it('caps component rows at 500 and rendered value rows at 1,000', () => {
+    const { panel } = createRuntimeHarness();
+    const root = makeRuntimeNode(0);
+    root.children = Array.from({ length: 500 }, (_value, index) => makeRuntimeNode(index + 1));
+
+    const components = panel.collectRuntimeStateComponents(root);
+    const context = makeValueContext();
+    const markup = panel.renderRuntimeStateEntries(
+      Array.from({ length: 1001 }, (_value, index) => index),
+      context,
+      [],
+    );
+
+    expect(components.records.length).toBe(500);
+    expect(components.truncated).toBeTrue();
+    expect(context.rows).toBe(1000);
+    expect(context.truncated).toBeTrue();
+    expect(markup).toContain('Additional state rows were omitted.');
+    expect(markup).not.toContain('[1000]');
+  });
+
+  it('keeps repeated native subtrees distinct without offering path-only Inspect actions', () => {
+    const { panel } = createRuntimeHarness();
+    const makeNativeStateNode = (key: string, source: string, children: RuntimeNode[]): RuntimeNode => ({
+      children,
+      component: { state: source },
+      key,
+      tag: key === 'shared-key' ? 'RepeatedComponent' : 'BranchComponent',
+    });
+    const firstRepeated = makeNativeStateNode('shared-key', '{ value: 1 }', []);
+    const secondRepeated = makeNativeStateNode('shared-key', '{ value: 2 }', []);
+    const root: RuntimeNode = {
+      children: [
+        makeNativeStateNode('left-branch', '{ branch: 1 }', [firstRepeated]),
+        makeNativeStateNode('right-branch', '{ branch: 2 }', [secondRepeated]),
+      ],
+      key: 'root',
+      tag: 'Root',
+    };
+    panel.state.snapshot = { tree: root };
+
+    const records = panel.collectRuntimeStateComponents(root).records;
+    const repeatedRecords = records.filter(record => record.key === 'shared-key');
+    expect(repeatedRecords.map(record => record.structuralId)).toEqual(['[0,0]', '[1,0]']);
+    expect(repeatedRecords.every(record => record.selectableNodeId === null)).toBeTrue();
+    expect(repeatedRecords.every(record => record.sourceType === 'native')).toBeTrue();
+    expect(records.map(record => record.key)).toEqual(['left-branch', 'shared-key', 'right-branch', 'shared-key']);
+
+    panel.state.runtimeState.expandedComponents.add('[0,0]');
+    panel.renderRuntimeStateSection();
+    const markup = panel.elements.stateContent.innerHTML;
+    expect(markup).toContain('data-runtime-state-component-id="[0,0]" open');
+    expect(markup).toContain('data-runtime-state-component-id="[1,0]"');
+    expect(markup).not.toContain('data-runtime-state-component-id="[1,0]" open');
+    expect((markup.match(/shared-key/g) ?? []).length).toBe(2);
+    expect(markup).not.toContain('runtime-state-inspect');
+  });
+
+  it('omits Inspect when an explicit snapshot identity is duplicated', () => {
+    const { panel } = createRuntimeHarness();
+    const first = makeRuntimeNode(1);
+    const second = makeRuntimeNode(2);
+    first.id = 'duplicate';
+    second.id = 'duplicate';
+    const root: RuntimeNode = { children: [first, second], id: 'root', tag: 'Root' };
+    panel.state.snapshot = { tree: root };
+
+    const records = panel.collectRuntimeStateComponents(root).records;
+    expect(records.map(record => record.selectableNodeId)).toEqual([null, null]);
+    panel.renderRuntimeStateSection();
+    expect(panel.elements.stateContent.innerHTML).not.toContain('runtime-state-inspect');
+  });
+
+  it('keeps native parsing independent from an exact element identity', () => {
+    const { panel } = createRuntimeHarness();
+    const node: RuntimeNode = {
+      children: [],
+      component: { state: '{"value":"ambiguous native string"}' },
+      element: { id: 42 },
+      key: 'native-key',
+      tag: 'NativeComponent',
+    };
+    panel.state.snapshot = { tree: node };
+    panel.state.runtimeState.expandedComponents.add('[]');
+
+    const record = panel.runtimeStateComponentRecord(node, '[]');
+    expect(record?.selectableNodeId).toBe('42');
+    expect(record?.sourceType).toBe('native');
+    expect(record?.key).toBe('native-key');
+    panel.renderRuntimeStateSection();
+    expect(panel.elements.stateContent.innerHTML).toContain('bounded raw snapshot');
+    expect(panel.elements.stateContent.innerHTML).toContain('component 42');
+  });
+
+  it('does not fall back to element identity when an own node identity is malformed', () => {
+    const { panel } = createRuntimeHarness();
+    const node: RuntimeNode = {
+      children: [],
+      component: { state: '{ count: 1 }' },
+      element: { id: 42 },
+      id: '',
+      key: 'malformed-node-id',
+      tag: 'NativeComponent',
+    };
+    panel.state.snapshot = { tree: node };
+
+    expect(panel.runtimeStateComponentRecord(node, '[]')?.selectableNodeId).toBeNull();
+    panel.renderRuntimeStateSection();
+    expect(panel.elements.stateContent.innerHTML).not.toContain('runtime-state-inspect');
+  });
+
+  it('does not read inherited or accessor-backed snapshot fields in the State UI', () => {
+    const { panel } = createRuntimeHarness();
+    const getter = jasmine.createSpy('stateGetter').and.throwError('must not execute');
+    const accessorComponent: Record<string, unknown> = { key: 'key', name: 'Accessor' };
+    Object.defineProperty(accessorComponent, 'state', { enumerable: true, get: getter });
+    const accessorNode = makeRuntimeNode(1);
+    accessorNode.component = accessorComponent as NonNullable<RuntimeNode['component']>;
+    const inheritedComponent = Object.create({ state: '{"unsafe":true}' }) as NonNullable<RuntimeNode['component']>;
+    Object.defineProperties(inheritedComponent, {
+      key: { enumerable: true, value: 'key' },
+      name: { enumerable: true, value: 'Inherited' },
+    });
+    const inheritedNode = makeRuntimeNode(2);
+    inheritedNode.component = inheritedComponent;
+
+    expect(panel.runtimeStateComponentRecord(accessorNode, 'accessor')).toBeNull();
+    expect(panel.runtimeStateComponentRecord(inheritedNode, 'inherited')).toBeNull();
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('keeps State search independent and escapes component names, keys, and raw fallback text', () => {
+    const { panel } = createRuntimeHarness(
+      '?inspectedUrl=http%3A%2F%2F127.0.0.1%3A54321&targetNonce=runtime-state-nonce',
+    );
+    const matching = makeRuntimeNode(1, '{ malformed: <img src=x> }');
+    matching.component = { key: '<key>', name: '<script>needle</script>', state: '{ malformed: <img src=x> }' };
+    const other = makeRuntimeNode(2, '{"value":"other"}');
+    matching.children = [other];
+    panel.state.snapshot = { tree: matching };
+    panel.state.runtimeState.search = 'needle';
+    panel.state.runtimeState.expandedComponents.add('[]');
+
+    panel.renderRuntimeStateSection();
+
+    expect(panel.elements.stateSummary.textContent).toContain('1 of 2 components');
+    expect(panel.elements.stateContent.innerHTML).toContain('&lt;script&gt;needle&lt;/script&gt;');
+    expect(panel.elements.stateContent.innerHTML).toContain('&lt;key&gt;');
+    expect(panel.elements.stateContent.innerHTML).toContain('&lt;img src=x&gt;');
+    expect(panel.elements.stateContent.innerHTML).not.toContain('<script>');
+    expect(panel.elements.stateContent.innerHTML).not.toContain('<img src=x>');
+    expect(panel.elements.stateContent.innerHTML).toContain('component component-1');
+  });
+
+  it('rejects Inspect bindings after snapshot, target, selection, filter, disclosure, or node replacement', () => {
+    const { panel } = createRuntimeHarness();
+    const node = makeRuntimeNode(1);
+    panel.state.snapshot = { tree: node };
+    panel.state.snapshotGeneration = 4;
+    panel.state.runtimeState.inspectGeneration = 9;
+    const binding = () => ({
+      generation: panel.state.runtimeState.inspectGeneration,
+      node,
+      selectableNodeId: node.id,
+      snapshotGeneration: panel.state.snapshotGeneration,
+      source: node.component?.state,
+      structuralId: '[]',
+    });
+
+    const snapshotBinding = binding();
+    panel.state.snapshotGeneration++;
+    expect(panel.inspectRuntimeStateBinding(snapshotBinding)).toBeFalse();
+
+    const targetBinding = binding();
+    panel.resetRuntimeStateForTargetChange();
+    expect(panel.inspectRuntimeStateBinding(targetBinding)).toBeFalse();
+
+    const selectionBinding = binding();
+    panel.resetRuntimeStateForSelectionChange('different-component');
+    expect(panel.inspectRuntimeStateBinding(selectionBinding)).toBeFalse();
+
+    const filterBinding = binding();
+    panel.state.runtimeState.search = 'value';
+    panel.renderRuntimeStateSection();
+    expect(panel.inspectRuntimeStateBinding(filterBinding)).toBeFalse();
+
+    const disclosureBinding = binding();
+    const details = new StubElement('details', () => {});
+    details.dataset['runtimeStateComponentId'] = '[]';
+    details.open = true;
+    panel.updateRuntimeStateDisclosure(details);
+    expect(panel.inspectRuntimeStateBinding(disclosureBinding)).toBeFalse();
+
+    const replacementBinding = binding();
+    panel.state.snapshot = { tree: makeRuntimeNode(1) };
+    expect(panel.inspectRuntimeStateBinding(replacementBinding)).toBeFalse();
+  });
+
+  it('restores disclosure focus after a State subtree rerender', () => {
+    const harness = createRuntimeHarness();
+    const { panel } = harness;
+    const node = makeRuntimeNode(1);
+    panel.state.snapshot = { tree: node };
+    const oldSummary = new StubElement('old-summary', () => {});
+    const details = new StubElement('old-details', () => {});
+    details.dataset['runtimeStateComponentId'] = '[]';
+    details.open = true;
+    details.queryResults.set('summary', [oldSummary]);
+    const replacementSummary = new StubElement('replacement-summary', element => harness.setActiveElement(element));
+    const replacementDetails = new StubElement('replacement-details', () => {});
+    replacementDetails.dataset['runtimeStateComponentId'] = '[]';
+    replacementDetails.queryResults.set('summary', [replacementSummary]);
+    panel.elements.stateContent.queryResults.set('details', [replacementDetails]);
+    harness.setActiveElement(oldSummary);
+
+    panel.updateRuntimeStateDisclosure(details);
+
+    expect(panel.state.runtimeState.expandedComponents.has('[]')).toBeTrue();
+    expect(replacementSummary.focusCount).toBe(1);
+    expect(panel.elements.stateContent.querySelector('details')?.querySelector('summary')).toBe(replacementSummary);
+  });
+
+  it('provides roving, keyboard-operable detail tabs and labels the shared tabpanel', () => {
+    const harness = createRuntimeHarness();
+    const { detailTabs, panel } = harness;
+    const [stylesTab, computedTab, stateTab, domTab] = detailTabs;
+
+    panel.setActiveDetail('styles');
+    stylesTab.dispatch('keydown', { currentTarget: stylesTab, key: 'ArrowRight' });
+    expect(panel.state.activeDetail).toBe('computed');
+    expect(stylesTab.tabIndex).toBe(-1);
+    expect(computedTab.tabIndex).toBe(0);
+    expect(panel.elements.inspector.getAttribute('aria-labelledby')).toBe(computedTab.id);
+
+    computedTab.dispatch('keydown', { currentTarget: computedTab, key: 'End' });
+    expect(panel.state.activeDetail).toBe('dom');
+    domTab.dispatch('keydown', { currentTarget: domTab, key: 'Home' });
+    expect(panel.state.activeDetail).toBe('styles');
+    panel.setActiveDetail('state');
+    expect(stateTab.getAttribute('aria-selected')).toBe('true');
+    expect(stateTab.tabIndex).toBe(0);
+  });
+
+  it('blocks immediate, timer, and visibility refreshes while either State view owns focus', () => {
+    const harness = createRuntimeHarness();
+    const { fetchPaths, panel } = harness;
+    panel.state.target = { capabilities: ['components', 'snapshot'], id: 'runtime-state-test' };
+    panel.state.activeSection = 'state';
+    panel.startRefreshTimer();
+    const mainSummary = new StubElement('main-summary', element => harness.setActiveElement(element));
+    const inspectButton = new StubElement('inspect-button', element => harness.setActiveElement(element));
+    panel.elements.stateContent.containedElements.add(mainSummary);
+    panel.elements.stateContent.containedElements.add(inspectButton);
+
+    for (const control of [panel.elements.stateFilter, mainSummary, inspectButton]) {
+      control.focus();
+      void panel.refreshSnapshot();
+      harness.runIntervals();
+      harness.dispatchDocument('visibilitychange');
+    }
+
+    panel.state.activeSection = 'elements';
+    panel.state.activeDetail = 'state';
+    const inspectorSummary = new StubElement('inspector-summary', element => harness.setActiveElement(element));
+    panel.elements.inspector.containedElements.add(inspectorSummary);
+    inspectorSummary.focus();
+    void panel.refreshSnapshot();
+    harness.runIntervals();
+    harness.dispatchDocument('visibilitychange');
+    expect(fetchPaths.filter(pathname => pathname === '/api/devtools/snapshot').length).toBe(0);
+
+    harness.setActiveElement(null);
+    harness.runIntervals();
+    expect(fetchPaths.filter(pathname => pathname === '/api/devtools/snapshot').length).toBe(1);
+  });
+
+  it('discards an ordinary snapshot response when State takes focus in flight', async () => {
+    const harness = createRuntimeHarness();
+    const { panel } = harness;
+    const summary = new StubElement('main-summary', element => harness.setActiveElement(element));
+    panel.elements.stateContent.containedElements.add(summary);
+    panel.state.target = { capabilities: ['components', 'snapshot'], id: 'runtime-state-test' };
+    panel.state.activeSection = 'state';
+    panel.state.snapshotGeneration = 7;
+    harness.deferNextSnapshot();
+
+    const refresh = panel.refreshSnapshot();
+    summary.focus();
+    harness.resolveDeferredSnapshot();
+    await refresh;
+
+    expect(panel.state.snapshotGeneration).toBe(7);
+  });
+
+  it('keeps collapsed Inspect visible and transfers click focus to the State detail tab', () => {
+    const harness = createRuntimeHarness(
+      '?inspectedUrl=http%3A%2F%2F127.0.0.1%3A54321&targetNonce=runtime-state-nonce',
+    );
+    const { detailTabs, panel } = harness;
+    const node = makeRuntimeNode(1);
+    const inspectButton = new StubElement('inspect-button', element => harness.setActiveElement(element));
+    inspectButton.dataset['runtimeStateInspectSlot'] = '0';
+    inspectButton.closestResults.set('[data-runtime-state-inspect]', inspectButton);
+    panel.elements.stateContent.queryResults.set('[data-runtime-state-inspect-slot]', [inspectButton]);
+    panel.elements.stateContent.containedElements.add(inspectButton);
+    panel.state.target = { capabilities: ['components', 'snapshot'], id: 'runtime-state-test' };
+    panel.state.snapshot = { tree: node };
+    panel.state.snapshotGeneration = 3;
+    panel.state.activeSection = 'state';
+    inspectButton.focus();
+
+    panel.renderRuntimeStateSection();
+
+    const markup = panel.elements.stateContent.innerHTML;
+    expect(markup.indexOf('</details>')).toBeLessThan(markup.indexOf('class="runtime-state-inspect"'));
+    expect(markup).not.toContain('<details class="runtime-state-component-details" open');
+    panel.elements.stateContent.dispatch('click', { target: inspectButton });
+
+    const stateDetailTab = detailTabs.find(tab => tab.dataset['detail'] === 'state');
+    expect(panel.state.activeSection).toBe('elements');
+    expect(panel.state.activeDetail).toBe('state');
+    expect(panel.state.selectedNodeId).toBe(node.id);
+    expect(stateDetailTab?.focusCount).toBe(1);
+  });
+
+  it('suppresses State polling while a component property editor is focused or pending', () => {
+    const harness = createRuntimeHarness();
+    const { fetchPaths, panel } = harness;
+    panel.state.activeSection = 'state';
+    panel.state.target = { capabilities: ['components', 'snapshot'], id: 'runtime-state-test' };
+    panel.startRefreshTimer();
+
+    panel.state.componentPropertyEdit.focused = true;
+    panel.setActiveSection('state');
+    harness.runIntervals();
+    panel.state.componentPropertyEdit.focused = false;
+    panel.state.componentPropertyEdit.pending = true;
+    panel.setActiveSection('state');
+    harness.runIntervals();
+    expect(fetchPaths.filter(pathname => pathname === '/api/devtools/snapshot').length).toBe(0);
+
+    panel.state.componentPropertyEdit.pending = false;
+    harness.runIntervals();
+    expect(fetchPaths.filter(pathname => pathname === '/api/devtools/snapshot').length).toBe(1);
+  });
+
+  it('clears State search and expansions on target clear and inspected-page reconnect', async () => {
+    const directHarness = createRuntimeHarness();
+    const directRuntimeState = directHarness.panel.state.runtimeState;
+    directRuntimeState.search = 'stale';
+    directRuntimeState.expandedComponents.add('component');
+    directRuntimeState.expandedInspectorValues.add('inspector');
+    directRuntimeState.expandedMainValues.add('main');
+    directHarness.panel.elements.stateFilter.value = 'stale';
+
+    directHarness.panel.clearTargetPresentation('cleared');
+
+    expect(directRuntimeState.search).toBe('');
+    expect(directRuntimeState.expandedComponents.size).toBe(0);
+    expect(directRuntimeState.expandedInspectorValues.size).toBe(0);
+    expect(directRuntimeState.expandedMainValues.size).toBe(0);
+    expect(directHarness.panel.elements.stateFilter.value).toBe('');
+
+    const reconnectHarness = createRuntimeHarness(
+      '?inspectedUrl=http%3A%2F%2F127.0.0.1%3A54321&targetNonce=runtime-state-nonce',
+    );
+    reconnectHarness.panel.state.target = {
+      capabilities: ['components', 'snapshot'],
+      id: 'old-target',
+      sessionId: 'old-session',
+    };
+    reconnectHarness.panel.state.runtimeState.search = 'stale';
+    reconnectHarness.panel.state.runtimeState.expandedComponents.add('component');
+    reconnectHarness.setTargetPayload({
+      applicationUrl: 'http://127.0.0.1:54321',
+      capabilities: ['components', 'snapshot'],
+      debuggingPort: 54_321,
+      id: 'new-target',
+      name: 'New target',
+      sessionId: 'new-session',
+    });
+
+    await reconnectHarness.panel.connectToInspectedPage();
+    await flushPromises();
+
+    expect(reconnectHarness.panel.state.runtimeState.search).toBe('');
+    expect(reconnectHarness.panel.state.runtimeState.expandedComponents.size).toBe(0);
+    expect(reconnectHarness.panel.elements.stateFilter.value).toBe('');
+  });
+
+  it('declares State tabs, live summary semantics, and tabpanel relationships in static markup', () => {
+    const html = fs.readFileSync(path.resolve(process.cwd(), 'debugger', 'devtools-panel.html'), 'utf8');
+
+    expect(html).toContain('id="stateTab"');
+    expect(html).toContain('aria-controls="stateSection"');
+    expect(html).toContain('id="stateDetailTab"');
+    expect(html).toContain('aria-controls="inspector"');
+    expect(html).toContain('id="stateSummary" class="runtime-state-summary" role="status" aria-live="polite"');
+    expect(html).toContain('id="inspector" class="inspector" role="tabpanel"');
+  });
+});

--- a/src/valdi_modules/src/valdi/web_renderer/src/ValdiWebRendererDelegate.ts
+++ b/src/valdi_modules/src/valdi/web_renderer/src/ValdiWebRendererDelegate.ts
@@ -42,6 +42,7 @@ export interface WebRendererDebugNodeSnapshot {
     name: string;
     properties?: Record<string, unknown>;
     propertyEdits?: Record<string, WebRendererDebugPropertyEditMetadata>;
+    state?: string;
   };
   element?: {
     id: number;
@@ -83,6 +84,7 @@ export interface WebRendererDebugComponentSnapshot extends WebRendererDebugNodeS
     name: string;
     properties?: Record<string, unknown>;
     propertyEdits?: Record<string, WebRendererDebugPropertyEditMetadata>;
+    state?: string;
   };
 }
 
@@ -248,7 +250,7 @@ export class ValdiWebRendererDelegate implements IRendererDelegate {
   registerFrameObserver(observer: FrameObserver): void {
     this.frameObserver = observer;
 
-    this.resizeObserver = new ResizeObserver((entries) => {
+    this.resizeObserver = new ResizeObserver(entries => {
       if (!this.frameObserver) return;
 
       const updates: number[] = [];
@@ -348,8 +350,23 @@ export class ValdiWebRendererDelegate implements IRendererDelegate {
     if (JSON.stringify(componentSnapshot).length <= snapshotCharacterLimit) {
       return componentSnapshot;
     }
+    stripComponentState(componentTree);
+    if (JSON.stringify(componentSnapshot).length <= snapshotCharacterLimit) {
+      return componentSnapshot;
+    }
     stripComponentProperties(componentTree);
     return JSON.stringify(componentSnapshot).length <= snapshotCharacterLimit ? componentSnapshot : elementSnapshot;
+  }
+}
+
+function stripComponentState(root: WebRendererDebugNodeSnapshot): void {
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop()!;
+    if (node.component !== undefined) {
+      delete node.component.state;
+    }
+    pending.push(...node.children);
   }
 }
 
@@ -561,11 +578,7 @@ function captureDebugElementSnapshot(
   return snapshot;
 }
 
-function isLiveDebugNode(
-  node: WebValdiLayout,
-  expectedParent: WebValdiLayout | null,
-  nodesRef: NodesRef,
-): boolean {
+function isLiveDebugNode(node: WebValdiLayout, expectedParent: WebValdiLayout | null, nodesRef: NodesRef): boolean {
   return node.parent === expectedParent && nodesRef.get(node.id) === node;
 }
 
@@ -702,20 +715,13 @@ function toDebugValue(
   }
 }
 
-function captureDebugString(
-  value: string,
-  budget: DebugSerializationBudget,
-  reservedCharacters: number,
-): string {
+function captureDebugString(value: string, budget: DebugSerializationBudget, reservedCharacters: number): string {
   const availableCharacters = Math.min(
     budget.remainingCharacters,
     Math.max(2, budget.remainingCharacters - reservedCharacters),
   );
   const valueCharacterLimit = Math.min(value.length, MAX_DEBUG_STRING_CHARACTERS);
-  if (
-    value.length <= MAX_DEBUG_STRING_CHARACTERS &&
-    getJsonStringCharacterLength(value) <= availableCharacters
-  ) {
+  if (value.length <= MAX_DEBUG_STRING_CHARACTERS && getJsonStringCharacterLength(value) <= availableCharacters) {
     consumeDebugBudget(budget, getJsonStringCharacterLength(value));
     return value;
   }

--- a/src/valdi_modules/src/valdi/web_renderer/src/debug/ComponentHierarchySnapshot.ts
+++ b/src/valdi_modules/src/valdi/web_renderer/src/debug/ComponentHierarchySnapshot.ts
@@ -8,7 +8,11 @@ import type {
   WebRendererDebugNodeSnapshot,
   WebRendererDebugPropertyEditMetadata,
 } from '../ValdiWebRendererDelegate';
-import { captureDebuggerPropertiesSnapshot, type DebuggerValueSnapshotLimits } from './DebuggerValueSnapshot';
+import {
+  captureDebuggerPropertiesSnapshot,
+  captureDebuggerPropertiesSnapshotWithReflectionLimit,
+  type DebuggerValueSnapshotLimits,
+} from './DebuggerValueSnapshot';
 
 const MAX_COMPONENT_HIERARCHY_CHILD_LINKS = 1_000;
 const MAX_COMPONENT_HIERARCHY_DEPTH = 64;
@@ -19,6 +23,10 @@ const MAX_COMPONENT_NAME_CHARACTERS = 256;
 const MAX_COMPONENT_KEY_CHARACTERS = 256;
 const MAX_COMPONENT_PROTOTYPE_DEPTH = 16;
 const MAX_COMPONENT_PROPERTY_BYTES = 65_536;
+const MAX_COMPONENT_STATE_CAPTURE_ATTEMPTS = 1_000;
+const MAX_COMPONENT_STATE_CAPTURE_REFLECTION_OPERATIONS = 16_384;
+const MAX_COMPONENT_STATE_CAPTURE_WORK_BYTES = MAX_COMPONENT_PROPERTY_BYTES * 2;
+const MAX_COMPONENT_STATE_CHARACTERS = 65_536;
 const MAX_EDITABLE_VIEW_MODEL_OWN_KEYS = 1_000;
 const EDITABLE_PROPERTY_DESCRIPTOR_FIELDS: Array<keyof PropertyDescriptor> = [
   'configurable',
@@ -32,6 +40,13 @@ const COMPONENT_PROPERTY_LIMITS: DebuggerValueSnapshotLimits = {
   maximumDepth: 4,
   maximumEntries: 50,
   maximumPropertyNameCharacters: 256,
+  maximumStringBytes: 65_536,
+};
+const COMPONENT_STATE_LIMITS: DebuggerValueSnapshotLimits = {
+  // The synthetic wrapper consumes one level before the state value.
+  maximumDepth: 13,
+  maximumEntries: 100,
+  maximumPropertyNameCharacters: 1_024,
   maximumStringBytes: 65_536,
 };
 const FORBIDDEN_EDITABLE_PROPERTY_NAMES = new Set(['__proto__', 'children', 'constructor', 'prototype']);
@@ -64,10 +79,18 @@ interface CapturedHierarchyNode {
 interface CapturedVirtualNode extends RendererDebugVirtualNodeSnapshot {
   readonly node: IRenderedVirtualNode;
   componentOutput?: WebRendererDebugComponentSnapshot;
+  runtimeStateIdentity?: object;
 }
 
 interface ComponentPropertyBudget {
   remainingBytes: number;
+}
+
+interface ComponentStateCaptureWorkBudget {
+  exhausted: boolean;
+  remainingBytes: number;
+  remainingCaptureAttempts: number;
+  remainingReflectionOperations: number;
 }
 
 interface EditableViewModelShape {
@@ -127,6 +150,12 @@ export function captureComponentHierarchySnapshot(
 
   const capturedNodes: CapturedVirtualNode[] = [];
   const componentPropertyBudget: ComponentPropertyBudget = { remainingBytes: MAX_COMPONENT_PROPERTY_BYTES };
+  const componentStateCaptureWorkBudget: ComponentStateCaptureWorkBudget = {
+    exhausted: false,
+    remainingBytes: MAX_COMPONENT_STATE_CAPTURE_WORK_BYTES,
+    remainingCaptureAttempts: MAX_COMPONENT_STATE_CAPTURE_ATTEMPTS,
+    remainingReflectionOperations: MAX_COMPONENT_STATE_CAPTURE_REFLECTION_OPERATIONS,
+  };
   const componentIds = new Set<string>();
   const consumedChildCountByParentId = new Map<string | null, number>();
   const usedElementIds = new Set<string>();
@@ -228,6 +257,7 @@ export function captureComponentHierarchySnapshot(
         componentIds,
         consumedChildCountByParentId,
         componentPropertyBudget,
+        componentStateCaptureWorkBudget,
         componentPropertyEditRegistrar,
         usedElementIds,
       );
@@ -265,6 +295,7 @@ function captureCompletedFrame(
   componentIds: Set<string>,
   consumedChildCountByParentId: Map<string | null, number>,
   componentPropertyBudget: ComponentPropertyBudget,
+  componentStateCaptureWorkBudget: ComponentStateCaptureWorkBudget,
   componentPropertyEditRegistrar: ComponentPropertyEditRegistrar | undefined,
   usedElementIds: Set<string>,
 ): CapturedHierarchyNode | undefined {
@@ -318,6 +349,11 @@ function captureCompletedFrame(
       node: captured.node,
     },
   );
+  const runtimeStateCapture = captureComponentRuntimeState(
+    component,
+    componentPropertyBudget,
+    componentStateCaptureWorkBudget,
+  );
   const node: WebRendererDebugComponentSnapshot = {
     ...(backingElement === undefined ? {} : { bounds: backingElement.bounds }),
     children: frame.capturedChildren.map(child => child.node),
@@ -327,11 +363,13 @@ function captureCompletedFrame(
       name: componentName,
       ...(propertyCapture === undefined ? {} : { properties: propertyCapture.properties }),
       ...(propertyCapture?.propertyEdits === undefined ? {} : { propertyEdits: propertyCapture.propertyEdits }),
+      ...(runtimeStateCapture === undefined ? {} : { state: runtimeStateCapture.serialized }),
     },
     id: componentId,
     tag: componentName,
   };
   captured.componentOutput = node;
+  captured.runtimeStateIdentity = runtimeStateCapture?.identity;
   return {
     ...(firstElementId === undefined ? {} : { firstElementId }),
     node,
@@ -442,9 +480,17 @@ function isCapturedVirtualTopologyCurrent(
     ) {
       return false;
     }
-    if (current.componentViewModel !== captured.componentViewModel && captured.componentOutput !== undefined) {
-      delete captured.componentOutput.component.properties;
-      delete captured.componentOutput.component.propertyEdits;
+    if (captured.componentOutput !== undefined) {
+      if (current.componentViewModel !== captured.componentViewModel) {
+        delete captured.componentOutput.component.properties;
+        delete captured.componentOutput.component.propertyEdits;
+      }
+      if (
+        captured.runtimeStateIdentity !== undefined &&
+        !hasExactRuntimeStateIdentity(current.component, captured.runtimeStateIdentity)
+      ) {
+        delete captured.componentOutput.component.state;
+      }
     }
     remainingChildLinks -= children.length;
     remainingTraversalLinks -= current.traversedLinkCount;
@@ -469,6 +515,11 @@ interface ComponentPropertyCaptureIdentity {
 interface ComponentPropertyCapture {
   readonly properties: Record<string, unknown>;
   readonly propertyEdits?: Record<string, WebRendererDebugPropertyEditMetadata>;
+}
+
+interface ComponentRuntimeStateCapture {
+  readonly identity: object;
+  readonly serialized: string;
 }
 
 function captureComponentProperties(
@@ -503,6 +554,187 @@ function captureComponentProperties(
     properties: captured.value,
     ...(propertyEdits === undefined ? {} : { propertyEdits }),
   };
+}
+
+function captureComponentRuntimeState(
+  component: IComponent,
+  budget: ComponentPropertyBudget,
+  workBudget: ComponentStateCaptureWorkBudget,
+): ComponentRuntimeStateCapture | undefined {
+  if (
+    budget.remainingBytes <= 0 ||
+    workBudget.exhausted ||
+    workBudget.remainingBytes <= 0 ||
+    workBudget.remainingCaptureAttempts <= 0 ||
+    workBudget.remainingReflectionOperations <= 0
+  ) {
+    if (workBudget.remainingCaptureAttempts <= 0 || workBudget.remainingReflectionOperations <= 0) {
+      workBudget.exhausted = true;
+    }
+    return undefined;
+  }
+  try {
+    const stateDescriptor = Reflect.getOwnPropertyDescriptor(component, 'state');
+    if (
+      stateDescriptor?.enumerable !== true ||
+      !Object.prototype.hasOwnProperty.call(stateDescriptor, 'value') ||
+      typeof stateDescriptor.value !== 'object' ||
+      stateDescriptor.value === null
+    ) {
+      return undefined;
+    }
+    const identity = stateDescriptor.value;
+    const wrapper = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(wrapper, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: identity,
+      writable: true,
+    });
+    if (!consumeComponentStateCaptureAttempt(workBudget)) {
+      return undefined;
+    }
+    const captured = captureDebuggerPropertiesSnapshotWithReflectionLimit(
+      wrapper,
+      Math.min(MAX_COMPONENT_PROPERTY_BYTES, workBudget.remainingBytes),
+      workBudget.remainingReflectionOperations,
+      COMPONENT_STATE_LIMITS,
+    );
+    if (captured === undefined) {
+      exhaustComponentStateCaptureWork(workBudget);
+      return undefined;
+    }
+    if (
+      !consumeComponentStateCaptureWork(
+        workBudget,
+        captured.serializedBytes,
+        captured.reflectionOperations,
+        captured.unmeasurable,
+      )
+    ) {
+      return undefined;
+    }
+    const capturedDescriptor = Object.getOwnPropertyDescriptor(captured?.value ?? {}, 'state');
+    if (
+      capturedDescriptor?.enumerable !== true ||
+      !Object.prototype.hasOwnProperty.call(capturedDescriptor, 'value') ||
+      typeof capturedDescriptor.value !== 'object' ||
+      capturedDescriptor.value === null ||
+      !hasExactRuntimeStateIdentity(component, identity)
+    ) {
+      return undefined;
+    }
+    const serialized = JSON.stringify(capturedDescriptor.value);
+    if (typeof serialized !== 'string' || serialized.length > MAX_COMPONENT_STATE_CHARACTERS) {
+      return undefined;
+    }
+    const wireWrapper = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(wireWrapper, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: serialized,
+      writable: true,
+    });
+    if (workBudget.exhausted || workBudget.remainingBytes <= 0 || workBudget.remainingReflectionOperations <= 0) {
+      return undefined;
+    }
+    if (!consumeComponentStateCaptureAttempt(workBudget)) {
+      return undefined;
+    }
+    const wireCapture = captureDebuggerPropertiesSnapshotWithReflectionLimit(
+      wireWrapper,
+      Math.min(budget.remainingBytes, workBudget.remainingBytes),
+      workBudget.remainingReflectionOperations,
+      COMPONENT_STATE_LIMITS,
+    );
+    if (wireCapture === undefined) {
+      exhaustComponentStateCaptureWork(workBudget);
+      return undefined;
+    }
+    if (
+      !consumeComponentStateCaptureWork(
+        workBudget,
+        wireCapture.serializedBytes,
+        wireCapture.reflectionOperations,
+        wireCapture.unmeasurable,
+      )
+    ) {
+      return undefined;
+    }
+    const wireDescriptor = Object.getOwnPropertyDescriptor(wireCapture?.value ?? {}, 'state');
+    if (
+      wireDescriptor?.enumerable !== true ||
+      !Object.prototype.hasOwnProperty.call(wireDescriptor, 'value') ||
+      wireDescriptor.value !== serialized
+    ) {
+      return undefined;
+    }
+    budget.remainingBytes -= wireCapture.serializedBytes;
+    return { identity, serialized };
+  } catch (_error) {
+    // Throwing or revoked Proxy reflection is an expected trust-boundary
+    // outcome. Exhausting the aggregate work budget prevents repeated
+    // unmeasurable capture attempts while leaving properties intact.
+    exhaustComponentStateCaptureWork(workBudget);
+    return undefined;
+  }
+}
+
+function consumeComponentStateCaptureAttempt(budget: ComponentStateCaptureWorkBudget): boolean {
+  if (budget.exhausted || budget.remainingCaptureAttempts <= 0) {
+    exhaustComponentStateCaptureWork(budget);
+    return false;
+  }
+  budget.remainingCaptureAttempts--;
+  return true;
+}
+
+function consumeComponentStateCaptureWork(
+  budget: ComponentStateCaptureWorkBudget,
+  serializedBytes: number,
+  reflectionOperations: number,
+  unmeasurable: boolean,
+): boolean {
+  if (
+    budget.exhausted ||
+    unmeasurable ||
+    !Number.isSafeInteger(serializedBytes) ||
+    serializedBytes <= 0 ||
+    serializedBytes > budget.remainingBytes ||
+    !Number.isSafeInteger(reflectionOperations) ||
+    reflectionOperations < 0 ||
+    reflectionOperations > budget.remainingReflectionOperations
+  ) {
+    exhaustComponentStateCaptureWork(budget);
+    return false;
+  }
+  budget.remainingBytes -= serializedBytes;
+  budget.remainingReflectionOperations -= reflectionOperations;
+  budget.exhausted = budget.remainingBytes === 0 || budget.remainingReflectionOperations === 0;
+  return true;
+}
+
+function exhaustComponentStateCaptureWork(budget: ComponentStateCaptureWorkBudget): void {
+  budget.exhausted = true;
+  budget.remainingBytes = 0;
+  budget.remainingCaptureAttempts = 0;
+  budget.remainingReflectionOperations = 0;
+}
+
+function hasExactRuntimeStateIdentity(component: IComponent | undefined, identity: object): boolean {
+  if (component === undefined) return false;
+  try {
+    const descriptor = Reflect.getOwnPropertyDescriptor(component, 'state');
+    return (
+      descriptor?.enumerable === true &&
+      Object.prototype.hasOwnProperty.call(descriptor, 'value') &&
+      Object.is(descriptor.value, identity)
+    );
+  } catch (_error) {
+    // Revalidation may encounter a throwing or revoked Proxy. Treat it as a
+    // state-only identity mismatch without affecting the hierarchy snapshot.
+    return false;
+  }
 }
 
 function captureComponentPropertyEdits(

--- a/src/valdi_modules/src/valdi/web_renderer/src/debug/DebuggerValueSnapshot.ts
+++ b/src/valdi_modules/src/valdi/web_renderer/src/debug/DebuggerValueSnapshot.ts
@@ -6,12 +6,24 @@ export interface DebuggerValueSnapshotLimits {
 }
 
 export interface DebuggerValueSnapshotCapture<T> {
+  readonly reflectionOperations: number;
   readonly serializedBytes: number;
+  readonly unmeasurable: boolean;
   readonly value: T;
 }
 
 interface DebuggerValueSnapshotBudget {
+  reflectionOperations: number;
+  remainingReflectionOperations: number | undefined;
   remainingBytes: number;
+  unmeasurable: boolean;
+}
+
+interface DebuggerValueSnapshotCaptureOptions {
+  readonly limits: DebuggerValueSnapshotLimits;
+  readonly maximumReflectionOperations: number | undefined;
+  readonly maximumSerializedBytes: number;
+  readonly source: unknown;
 }
 
 const DEBUG_ACCESSOR_OMISSION_MARKER = 'accessors or unsupported fields omitted';
@@ -31,11 +43,50 @@ export function captureDebuggerPropertiesSnapshot(
   maximumSerializedBytes: number,
   limits: DebuggerValueSnapshotLimits,
 ): DebuggerValueSnapshotCapture<Record<string, unknown>> | undefined {
+  return captureDebuggerPropertiesSnapshotInternal({
+    limits,
+    maximumReflectionOperations: undefined,
+    maximumSerializedBytes,
+    source,
+  });
+}
+
+/**
+ * State-only variant that bounds descriptor reflection after each unavoidable
+ * own-name materialization. Ordinary property snapshots intentionally retain
+ * their existing unlimited reflection behavior.
+ */
+export function captureDebuggerPropertiesSnapshotWithReflectionLimit(
+  source: unknown,
+  maximumSerializedBytes: number,
+  maximumReflectionOperations: number,
+  limits: DebuggerValueSnapshotLimits,
+): DebuggerValueSnapshotCapture<Record<string, unknown>> | undefined {
+  if (!validMaximum(maximumReflectionOperations)) {
+    return undefined;
+  }
+  return captureDebuggerPropertiesSnapshotInternal({
+    limits,
+    maximumReflectionOperations,
+    maximumSerializedBytes,
+    source,
+  });
+}
+
+function captureDebuggerPropertiesSnapshotInternal(
+  options: DebuggerValueSnapshotCaptureOptions,
+): DebuggerValueSnapshotCapture<Record<string, unknown>> | undefined {
+  const { limits, maximumReflectionOperations, maximumSerializedBytes, source } = options;
   if (typeof source !== 'object' || source === null || !validMaximum(maximumSerializedBytes) || !validLimits(limits)) {
     return undefined;
   }
 
-  const budget: DebuggerValueSnapshotBudget = { remainingBytes: maximumSerializedBytes };
+  const budget: DebuggerValueSnapshotBudget = {
+    reflectionOperations: 0,
+    remainingReflectionOperations: maximumReflectionOperations,
+    remainingBytes: maximumSerializedBytes,
+    unmeasurable: false,
+  };
   try {
     if (Array.isArray(source)) {
       return undefined;
@@ -44,7 +95,14 @@ export function captureDebuggerPropertiesSnapshot(
     const value = captureObject(source, 0, activePath, budget, limits);
     const serialized = JSON.stringify(value);
     const serializedBytes = utf8ByteLength(serialized);
-    return serializedBytes <= maximumSerializedBytes ? { serializedBytes, value } : undefined;
+    return serializedBytes <= maximumSerializedBytes
+      ? {
+          reflectionOperations: budget.reflectionOperations,
+          serializedBytes,
+          unmeasurable: budget.unmeasurable,
+          value,
+        }
+      : undefined;
   } catch (_error) {
     // Throwing or revoked Proxy reflection is an expected trust-boundary
     // outcome. The caller treats undefined as a properties-only omission.
@@ -118,6 +176,7 @@ function captureValue(
   } catch (_error) {
     // A nested throwing Proxy is represented without discarding safe sibling
     // fields; its enclosing top-level capture remains detached and bounded.
+    markReflectionUnmeasurable(budget);
     return captureString(DEBUG_UNAVAILABLE_MARKER, budget, limits.maximumStringBytes);
   } finally {
     activePath.delete(value);
@@ -135,6 +194,9 @@ function captureArray(
   if (!tryConsumeBudget(budget, 2)) {
     return output;
   }
+  if (!consumeReflectionOperations(budget, 1)) {
+    return output;
+  }
   const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
   const length =
     typeof lengthDescriptor?.value === 'number' && Number.isSafeInteger(lengthDescriptor.value)
@@ -144,6 +206,9 @@ function captureArray(
   let inspectedItemCount = 0;
   for (; inspectedItemCount < itemCount; inspectedItemCount++) {
     if (!tryConsumeArrayItemPrefix(output, budget, 2)) {
+      break;
+    }
+    if (!consumeReflectionOperations(budget, 1)) {
       break;
     }
     const descriptor = Object.getOwnPropertyDescriptor(value, String(inspectedItemCount));
@@ -178,13 +243,24 @@ function captureObject(
   if (!tryConsumeBudget(budget, 2)) {
     return output;
   }
+  if (reflectionBudgetIsExhausted(budget)) {
+    markReflectionUnmeasurable(budget);
+    return output;
+  }
   let inspectedEntryCount = 0;
   let omitted = false;
   // JavaScript has no resumable own-key iterator. This may materialize a
   // Proxy's complete own-key result, but it never traverses the prototype.
   // Property values are still read only from data descriptors.
   const propertyNames = Object.getOwnPropertyNames(value);
+  if (!consumeReflectionOperations(budget, propertyNames.length)) {
+    return output;
+  }
   for (const propertyName of propertyNames) {
+    if (!consumeObjectDescriptorReflection(budget)) {
+      omitted = true;
+      break;
+    }
     const descriptor = Object.getOwnPropertyDescriptor(value, propertyName);
     if (descriptor === undefined || !descriptor.enumerable) {
       continue;
@@ -211,6 +287,42 @@ function captureObject(
     addTruncationProperty(output, DEBUG_ACCESSOR_OMISSION_MARKER, budget, limits);
   }
   return output;
+}
+
+function consumeObjectDescriptorReflection(budget: DebuggerValueSnapshotBudget): boolean {
+  if (budget.remainingReflectionOperations === undefined) {
+    return true;
+  }
+  return consumeReflectionOperations(budget, 1);
+}
+
+function consumeReflectionOperations(budget: DebuggerValueSnapshotBudget, count: number): boolean {
+  if (!Number.isSafeInteger(count) || count < 0 || budget.reflectionOperations > Number.MAX_SAFE_INTEGER - count) {
+    budget.reflectionOperations = Number.MAX_SAFE_INTEGER;
+    markReflectionUnmeasurable(budget);
+    return false;
+  }
+  budget.reflectionOperations += count;
+  if (budget.remainingReflectionOperations === undefined) {
+    return true;
+  }
+  if (count > budget.remainingReflectionOperations) {
+    markReflectionUnmeasurable(budget);
+    return false;
+  }
+  budget.remainingReflectionOperations -= count;
+  return true;
+}
+
+function markReflectionUnmeasurable(budget: DebuggerValueSnapshotBudget): void {
+  budget.unmeasurable = true;
+  if (budget.remainingReflectionOperations !== undefined) {
+    budget.remainingReflectionOperations = 0;
+  }
+}
+
+function reflectionBudgetIsExhausted(budget: DebuggerValueSnapshotBudget): boolean {
+  return budget.remainingReflectionOperations !== undefined && budget.remainingReflectionOperations <= 0;
 }
 
 function addTruncationProperty(

--- a/src/valdi_modules/src/valdi/web_renderer/test/DebuggerValueSnapshot.spec.ts
+++ b/src/valdi_modules/src/valdi/web_renderer/test/DebuggerValueSnapshot.spec.ts
@@ -1,6 +1,7 @@
 import 'jasmine/src/jasmine';
 import {
   captureDebuggerPropertiesSnapshot,
+  captureDebuggerPropertiesSnapshotWithReflectionLimit,
   type DebuggerValueSnapshotLimits,
 } from '../src/debug/DebuggerValueSnapshot';
 
@@ -109,6 +110,115 @@ describe('DebuggerValueSnapshot', () => {
     const revocable = Proxy.revocable({ visible: 'value' }, {});
     revocable.revoke();
     expect(captureDebuggerPropertiesSnapshot(revocable.proxy, 65_536, LIMITS)).toBeUndefined();
+  });
+
+  it('reports all materialized own names and array descriptor inspections as reflection work', () => {
+    const source: Record<string, unknown> = {};
+    for (let index = 0; index < 100; index++) {
+      Object.defineProperty(source, `hidden-${index}`, { enumerable: false, value: index });
+    }
+    source.visible = [1, 2];
+
+    const captured = captureDebuggerPropertiesSnapshot(source, 65_536, LIMITS);
+
+    expect(captured?.reflectionOperations).toBe(104);
+    expect(captured?.unmeasurable).toBeFalse();
+  });
+
+  it('bounds descriptor reflection immediately after own-name materialization', () => {
+    const propertyNames = Array.from({ length: 16_385 }, (_value, index) => `hidden-${index}`);
+    let descriptorReads = 0;
+    const state = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor: () => {
+          descriptorReads++;
+          return { configurable: true, enumerable: false, value: true };
+        },
+        ownKeys: () => propertyNames,
+      },
+    );
+
+    const captured = captureDebuggerPropertiesSnapshotWithReflectionLimit({ state }, 65_536, 16_384, LIMITS);
+
+    expect(descriptorReads).toBe(0);
+    expect(captured?.unmeasurable).toBeTrue();
+    expect(captured?.reflectionOperations).toBeGreaterThan(16_384);
+  });
+
+  it('checks the bounded allowance before each object descriptor lookup', () => {
+    const descriptorNames: string[] = [];
+    const source = new Proxy(
+      { first: 1, second: 2, third: 3 },
+      {
+        getOwnPropertyDescriptor: (target, propertyName) => {
+          descriptorNames.push(String(propertyName));
+          return Reflect.getOwnPropertyDescriptor(target, propertyName);
+        },
+      },
+    );
+
+    const captured = captureDebuggerPropertiesSnapshotWithReflectionLimit(source, 65_536, 4, LIMITS);
+
+    expect(descriptorNames).toEqual(['first']);
+    expect(captured?.unmeasurable).toBeTrue();
+  });
+
+  it('checks the bounded allowance before each array descriptor lookup', () => {
+    const descriptorNames: string[] = [];
+    const values = new Proxy([1, 2, 3], {
+      getOwnPropertyDescriptor: (target, propertyName) => {
+        descriptorNames.push(String(propertyName));
+        return Reflect.getOwnPropertyDescriptor(target, propertyName);
+      },
+    });
+
+    const captured = captureDebuggerPropertiesSnapshotWithReflectionLimit({ values }, 65_536, 4, LIMITS);
+
+    expect(descriptorNames).toEqual(['length', '0']);
+    expect(captured?.unmeasurable).toBeTrue();
+  });
+
+  it('accepts a document that uses the exact bounded reflection allowance', () => {
+    const captured = captureDebuggerPropertiesSnapshotWithReflectionLimit({ value: true }, 65_536, 2, LIMITS);
+
+    expect(captured?.value.value).toBeTrue();
+    expect(captured?.reflectionOperations).toBe(2);
+    expect(captured?.unmeasurable).toBeFalse();
+  });
+
+  it('accepts an array that uses the exact bounded reflection allowance', () => {
+    const descriptorNames: string[] = [];
+    const values = new Proxy([1], {
+      getOwnPropertyDescriptor: (target, propertyName) => {
+        descriptorNames.push(String(propertyName));
+        return Reflect.getOwnPropertyDescriptor(target, propertyName);
+      },
+    });
+
+    const captured = captureDebuggerPropertiesSnapshotWithReflectionLimit({ values }, 65_536, 4, LIMITS);
+
+    expect(descriptorNames).toEqual(['length', '0']);
+    expect(captured?.value.values).toEqual([1]);
+    expect(captured?.reflectionOperations).toBe(4);
+    expect(captured?.unmeasurable).toBeFalse();
+  });
+
+  it('marks nested reflection recovery as unmeasurable', () => {
+    const nested = new Proxy(
+      { value: true },
+      {
+        getOwnPropertyDescriptor: () => {
+          throw new Error('unavailable');
+        },
+      },
+    );
+
+    const captured = captureDebuggerPropertiesSnapshot({ nested, safe: true }, 65_536, LIMITS);
+
+    expect(captured?.value.nested).toBe('<unavailable/>');
+    expect(captured?.value.safe).toBeTrue();
+    expect(captured?.unmeasurable).toBeTrue();
   });
 
   it('does not traverse Proxy prototypes while capturing own fields', () => {

--- a/src/valdi_modules/src/valdi/web_renderer/test/LegacyWebDebuggerAdapter.spec.ts
+++ b/src/valdi_modules/src/valdi/web_renderer/test/LegacyWebDebuggerAdapter.spec.ts
@@ -3,10 +3,7 @@ import type { IComponent } from 'valdi_core/src/IComponent';
 import type { IRenderedElement } from 'valdi_core/src/IRenderedElement';
 import type { IRenderedVirtualNode } from 'valdi_core/src/IRenderedVirtualNode';
 import type { IRenderer } from 'valdi_core/src/IRenderer';
-import {
-  MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS,
-  ValdiWebRendererDelegate,
-} from '../src/ValdiWebRendererDelegate';
+import { MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS, ValdiWebRendererDelegate } from '../src/ValdiWebRendererDelegate';
 import type { WebValdiLayout } from '../src/views/WebValdiLayout';
 
 interface InstalledDom {
@@ -173,11 +170,7 @@ function installDom(): InstalledDom {
   };
 }
 
-function makeRenderedElement(
-  id: number,
-  tag: string,
-  attributes: Record<string, unknown>,
-): IRenderedElement {
+function makeRenderedElement(id: number, tag: string, attributes: Record<string, unknown>): IRenderedElement {
   return {
     id,
     tag,
@@ -247,10 +240,7 @@ function makeHierarchyRenderer(
   });
 }
 
-function captureSnapshot(
-  delegate: ValdiWebRendererDelegate,
-  elements: IRenderedElement[],
-) {
+function captureSnapshot(delegate: ValdiWebRendererDelegate, elements: IRenderedElement[]) {
   return delegate.getDebugSnapshot(makeRenderer(elements), MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS);
 }
 
@@ -274,10 +264,7 @@ function makeMutationMetadata(mutation: () => void): Record<string, unknown> {
   );
 }
 
-function observeIndexedChildReads(
-  children: WebValdiLayout[],
-  onIndexedRead: () => void,
-): WebValdiLayout[] {
+function observeIndexedChildReads(children: WebValdiLayout[], onIndexedRead: () => void): WebValdiLayout[] {
   return new Proxy(children, {
     get: (target, property, receiver) => {
       if (typeof property === 'string' && /^(0|[1-9]\d*)$/.test(property)) {
@@ -511,6 +498,299 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
     expect(snapshot.tree?.component?.name).toBe('SafeComponent');
     expect(snapshot.tree?.component?.properties?.visible).toBe('safe');
     expect(Object.prototype.hasOwnProperty.call(snapshot.tree?.component?.properties ?? {}, 'secret')).toBeFalse();
+  });
+
+  it('captures only the component instance own enumerable state data descriptor', () => {
+    class StatefulExampleComponent {}
+
+    const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+    delegate.onElementCreated(1, 'layout');
+    delegate.onElementBecameRoot(1);
+    const element = makeRenderedElement(1, 'layout', {});
+    const componentInstance = new StatefulExampleComponent() as unknown as IComponent;
+    const stateIdentity = { count: 4, nested: { ready: true } };
+    Object.defineProperty(componentInstance, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: stateIdentity,
+      writable: true,
+    });
+    const component = makeVirtualNode('stateful', { component: componentInstance });
+    component.componentViewModel = { state: { count: 99 }, title: 'ViewModel data remains independent' };
+    const elementNode = makeVirtualNode('layout', { element });
+    setVirtualChildren(component, [elementNode]);
+
+    const snapshot = delegate.getDebugSnapshot(
+      makeHierarchyRenderer([element], component),
+      MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS,
+    );
+
+    expect(JSON.parse(snapshot.tree?.component?.state ?? 'null')).toEqual(stateIdentity);
+    expect(snapshot.tree?.component?.properties?.state).toEqual({ count: 99 });
+  });
+
+  it('omits inherited, accessor, non-enumerable, scalar, and null component state without invoking getters', () => {
+    class RestrictedStateComponent {}
+
+    const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+    delegate.onElementCreated(1, 'layout');
+    delegate.onElementBecameRoot(1);
+    const element = makeRenderedElement(1, 'layout', {});
+    const componentInstance = new RestrictedStateComponent() as unknown as IComponent;
+    const component = makeVirtualNode('restricted-state', { component: componentInstance });
+    const elementNode = makeVirtualNode('layout', { element });
+    setVirtualChildren(component, [elementNode]);
+    const renderer = makeHierarchyRenderer([element], component);
+    const getter = jasmine.createSpy('stateGetter').and.throwError('must not execute');
+
+    Object.defineProperty(componentInstance, 'state', { configurable: true, enumerable: true, get: getter });
+    expect(
+      delegate.getDebugSnapshot(renderer, MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS).tree?.component?.state,
+    ).toBeUndefined();
+    expect(getter).not.toHaveBeenCalled();
+
+    Object.defineProperty(componentInstance, 'state', {
+      configurable: true,
+      enumerable: false,
+      value: { hidden: true },
+    });
+    expect(
+      delegate.getDebugSnapshot(renderer, MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS).tree?.component?.state,
+    ).toBeUndefined();
+
+    for (const value of [null, 3, 'text', true]) {
+      Object.defineProperty(componentInstance, 'state', { configurable: true, enumerable: true, value });
+      expect(
+        delegate.getDebugSnapshot(renderer, MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS).tree?.component?.state,
+      ).toBeUndefined();
+    }
+
+    delete (componentInstance as unknown as Record<string, unknown>)['state'];
+    Object.defineProperty(Object.getPrototypeOf(componentInstance), 'state', {
+      configurable: true,
+      enumerable: true,
+      value: { inherited: true },
+    });
+    try {
+      expect(
+        delegate.getDebugSnapshot(renderer, MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS).tree?.component?.state,
+      ).toBeUndefined();
+    } finally {
+      delete (Object.getPrototypeOf(componentInstance) as Record<string, unknown>)['state'];
+    }
+
+    const revokedState = Proxy.revocable({ visible: true }, {});
+    Object.defineProperty(componentInstance, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: revokedState.proxy,
+    });
+    revokedState.revoke();
+    const revokedSnapshot = delegate.getDebugSnapshot(renderer, MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS);
+    expect(revokedSnapshot.tree?.component?.state).toBeUndefined();
+    expect(revokedSnapshot.tree?.children[0].id).toBe('1');
+  });
+
+  it('charges the escaped runtime-state wire string against the shared component budget', () => {
+    class EscapedStateComponent {}
+
+    const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+    delegate.onElementCreated(1, 'layout');
+    delegate.onElementBecameRoot(1);
+    const element = makeRenderedElement(1, 'layout', {});
+    const componentInstance = new EscapedStateComponent() as unknown as IComponent;
+    Object.defineProperty(componentInstance, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: { payload: '"\\'.repeat(12_000) },
+    });
+    const component = makeVirtualNode('escaped-state', { component: componentInstance });
+    component.componentViewModel = { retained: 'property' };
+    const elementNode = makeVirtualNode('layout', { element });
+    setVirtualChildren(component, [elementNode]);
+
+    const snapshot = delegate.getDebugSnapshot(
+      makeHierarchyRenderer([element], component),
+      MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS,
+    );
+
+    expect(snapshot.tree?.component?.properties).toEqual({ retained: 'property' });
+    expect(snapshot.tree?.component?.state).toBeUndefined();
+    expect(snapshot.tree?.children[0].id).toBe('1');
+  });
+
+  it('admits escaped state only when its exact transported wrapper fits 64 KiB', () => {
+    class EscapedStateComponent {}
+
+    const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+    delegate.onElementCreated(1, 'layout');
+    delegate.onElementBecameRoot(1);
+    const element = makeRenderedElement(1, 'layout', {});
+    const componentInstance = new EscapedStateComponent() as unknown as IComponent;
+    Object.defineProperty(componentInstance, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: { payload: '"\\'.repeat(4_000) },
+    });
+    const component = makeVirtualNode('escaped-state-small', { component: componentInstance });
+    const elementNode = makeVirtualNode('layout', { element });
+    setVirtualChildren(component, [elementNode]);
+
+    const snapshot = delegate.getDebugSnapshot(
+      makeHierarchyRenderer([element], component),
+      MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS,
+    );
+    const serializedState = snapshot.tree?.component?.state;
+
+    expect(serializedState).toBeDefined();
+    expect(new TextEncoder().encode(JSON.stringify({ state: serializedState })).length).toBeLessThanOrEqual(65_536);
+    expect(JSON.parse(serializedState ?? 'null')).toEqual({ payload: '"\\'.repeat(4_000) });
+  });
+
+  it('bounds aggregate state capture work across a hierarchy without consuming the property budget', () => {
+    class WorkBoundedStateComponent {}
+
+    const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+    delegate.onElementCreated(1, 'layout');
+    delegate.onElementBecameRoot(1);
+    const element = makeRenderedElement(1, 'layout', {});
+    let escapedStateOwnKeyReads = 0;
+    let oversizedStateOwnKeyReads = 0;
+    let laterStateOwnKeyReads = 0;
+    const escapedState = new Proxy(
+      { payload: '"\\'.repeat(12_000) },
+      {
+        ownKeys: target => {
+          escapedStateOwnKeyReads++;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+    const oversizedState = new Proxy(
+      { payload: 'x'.repeat(100_000) },
+      {
+        ownKeys: target => {
+          oversizedStateOwnKeyReads++;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+    const laterState = new Proxy(
+      { retained: true },
+      {
+        ownKeys: target => {
+          laterStateOwnKeyReads++;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+    const makeComponentNode = (key: string, state: object, retained: number): MutableVirtualNode => {
+      const instance = new WorkBoundedStateComponent() as unknown as IComponent;
+      Object.defineProperty(instance, 'state', { enumerable: true, value: state });
+      const node = makeVirtualNode(key, { component: instance });
+      node.componentViewModel = { retained };
+      return node;
+    };
+    const childComponents = Array.from({ length: 998 }, (_value, index) =>
+      makeComponentNode(`work-${index}`, index === 0 ? escapedState : index === 1 ? oversizedState : laterState, index),
+    );
+    const rootInstance = new WorkBoundedStateComponent() as unknown as IComponent;
+    Object.defineProperty(rootInstance, 'state', { enumerable: true, value: laterState });
+    const rootComponent = makeVirtualNode('work-root', { component: rootInstance });
+    rootComponent.componentViewModel = { payload: 'p'.repeat(40_000) };
+    const elementNode = makeVirtualNode('layout', { element });
+    setVirtualChildren(rootComponent, [...childComponents, elementNode]);
+
+    const snapshot = delegate.getDebugSnapshot(
+      makeHierarchyRenderer([element], rootComponent),
+      MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS,
+    );
+
+    expect(escapedStateOwnKeyReads).toBeGreaterThan(0);
+    expect(oversizedStateOwnKeyReads).toBeGreaterThan(0);
+    expect(laterStateOwnKeyReads).toBe(0);
+    expect(snapshot.tree?.children.length).toBe(999);
+    expect(snapshot.tree?.children[0].component?.properties?.retained).toBe(0);
+    expect(snapshot.tree?.children[0].component?.state).toBeUndefined();
+    expect(snapshot.tree?.children[997].component?.properties?.retained).toBe(997);
+    expect(snapshot.tree?.children[997].component?.state).toBeUndefined();
+    expect(String(snapshot.tree?.component?.properties?.payload).length).toBe(40_000);
+    expect(snapshot.tree?.component?.state).toBeUndefined();
+    expect(snapshot.tree?.children[998].id).toBe('1');
+  });
+
+  it('fails closed on excessive or unmeasurable nested state reflection work', () => {
+    class ReflectedStateComponent {}
+
+    const expensiveStates: object[] = [];
+    const propertyNames = Array.from({ length: 16_385 }, (_value, index) => `hidden-${index}`);
+    let excessiveStateDescriptorReads = 0;
+    expensiveStates.push(
+      new Proxy(
+        {},
+        {
+          getOwnPropertyDescriptor: () => {
+            excessiveStateDescriptorReads++;
+            return { configurable: true, enumerable: false, value: true };
+          },
+          ownKeys: () => propertyNames,
+        },
+      ),
+    );
+    expensiveStates.push({
+      nested: new Proxy(
+        { value: true },
+        {
+          getOwnPropertyDescriptor: () => {
+            throw new Error('unavailable');
+          },
+        },
+      ),
+    });
+
+    for (const expensiveState of expensiveStates) {
+      const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+      delegate.onElementCreated(1, 'layout');
+      delegate.onElementBecameRoot(1);
+      const element = makeRenderedElement(1, 'layout', {});
+      let laterStateOwnKeyReads = 0;
+      const laterState = new Proxy(
+        { safe: true },
+        {
+          ownKeys: target => {
+            laterStateOwnKeyReads++;
+            return Reflect.ownKeys(target);
+          },
+        },
+      );
+      const makeComponentNode = (key: string, state: object): MutableVirtualNode => {
+        const instance = new ReflectedStateComponent() as unknown as IComponent;
+        Object.defineProperty(instance, 'state', { enumerable: true, value: state });
+        const node = makeVirtualNode(key, { component: instance });
+        node.componentViewModel = { retained: key };
+        return node;
+      };
+      const expensiveComponent = makeComponentNode('expensive', expensiveState);
+      const laterComponent = makeComponentNode('later', laterState);
+      const rootComponent = makeComponentNode('root', laterState);
+      const elementNode = makeVirtualNode('layout', { element });
+      setVirtualChildren(rootComponent, [expensiveComponent, laterComponent, elementNode]);
+
+      const snapshot = delegate.getDebugSnapshot(
+        makeHierarchyRenderer([element], rootComponent),
+        MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS,
+      );
+
+      expect(laterStateOwnKeyReads).toBe(0);
+      expect(snapshot.tree?.children[0].component?.state).toBeUndefined();
+      expect(snapshot.tree?.children[0].component?.properties?.retained).toBe('expensive');
+      expect(snapshot.tree?.children[1].component?.state).toBeUndefined();
+      expect(snapshot.tree?.children[1].component?.properties?.retained).toBe('later');
+      expect(snapshot.tree?.component?.state).toBeUndefined();
+      expect(snapshot.tree?.component?.properties?.retained).toBe('root');
+      expect(snapshot.tree?.children[2].id).toBe('1');
+    }
+    expect(excessiveStateDescriptorReads).toBe(0);
   });
 
   it('registers only exact captured own scalar data descriptors for component edits', () => {
@@ -771,6 +1051,11 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
     const component = makeVirtualNode('replaced-view-model', {
       component: new ReplacedViewModelComponent() as unknown as IComponent,
     });
+    Object.defineProperty(component.component, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: { retained: true },
+    });
     const elementNode = makeVirtualNode('layout', { element });
     setVirtualChildren(component, [elementNode]);
     const baseRenderer = makeHierarchyRenderer([element], component);
@@ -801,7 +1086,81 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
     expect(componentSnapshotReads).toBe(2);
     expect(snapshot.tree?.component?.name).toBe('ReplacedViewModelComponent');
     expect(snapshot.tree?.component?.properties).toBeUndefined();
+    expect(JSON.parse(snapshot.tree?.component?.state ?? 'null')).toEqual({ retained: true });
     expect(snapshot.tree?.children[0].id).toBe('1');
+  });
+
+  it('drops only runtime state when its exact component identity changes during capture', () => {
+    class ReplacedStateComponent {}
+
+    const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+    delegate.onElementCreated(1, 'layout');
+    delegate.onElementBecameRoot(1);
+    const element = makeRenderedElement(1, 'layout', {});
+    const componentInstance = new ReplacedStateComponent() as unknown as IComponent;
+    Object.defineProperty(componentInstance, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: { value: 'stale' },
+      writable: true,
+    });
+    const component = makeVirtualNode('replaced-state', { component: componentInstance });
+    component.componentViewModel = { retained: 'property' };
+    const elementNode = makeVirtualNode('layout', { element });
+    setVirtualChildren(component, [elementNode]);
+    const baseRenderer = makeHierarchyRenderer([element], component);
+    const readSnapshot = baseRenderer.getDebugVirtualNodeSnapshot!;
+    let componentSnapshotReads = 0;
+    const renderer = Object.assign(baseRenderer, {
+      getDebugVirtualNodeSnapshot: (
+        node: IRenderedVirtualNode,
+        maximumChildLinks: number,
+        maximumTraversalLinks: number,
+      ) => {
+        const snapshot = readSnapshot.call(baseRenderer, node, maximumChildLinks, maximumTraversalLinks);
+        if (snapshot !== undefined && node === (component as unknown as IRenderedVirtualNode)) {
+          componentSnapshotReads++;
+          if (componentSnapshotReads === 2) {
+            (componentInstance as unknown as Record<string, unknown>)['state'] = { value: 'fresh' };
+          }
+        }
+        return snapshot;
+      },
+    });
+
+    const snapshot = delegate.getDebugSnapshot(renderer, MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS);
+
+    expect(componentSnapshotReads).toBe(2);
+    expect(snapshot.tree?.component?.state).toBeUndefined();
+    expect(snapshot.tree?.component?.properties).toEqual({ retained: 'property' });
+    expect(snapshot.tree?.children[0].id).toBe('1');
+  });
+
+  it('uses properties first and omits runtime state when the shared 64 KiB budget is exhausted', () => {
+    class BudgetedStateComponent {}
+
+    const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+    delegate.onElementCreated(1, 'layout');
+    delegate.onElementBecameRoot(1);
+    const element = makeRenderedElement(1, 'layout', {});
+    const componentInstance = new BudgetedStateComponent() as unknown as IComponent;
+    Object.defineProperty(componentInstance, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: { payload: 's'.repeat(30_000) },
+    });
+    const component = makeVirtualNode('budgeted-state', { component: componentInstance });
+    component.componentViewModel = { payload: 'p'.repeat(40_000) };
+    const elementNode = makeVirtualNode('layout', { element });
+    setVirtualChildren(component, [elementNode]);
+
+    const snapshot = delegate.getDebugSnapshot(
+      makeHierarchyRenderer([element], component),
+      MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS,
+    );
+
+    expect(String(snapshot.tree?.component?.properties?.payload).length).toBe(40_000);
+    expect(snapshot.tree?.component?.state).toBeUndefined();
   });
 
   it('strips component properties before the complete hierarchy envelope overflows', () => {
@@ -831,6 +1190,45 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
     expect(snapshot.tree?.id).toBe('component:[null,"property-heavy"]');
     expect(snapshot.tree?.component?.name).toBe('PropertyHeavyComponent');
     expect(snapshot.tree?.component?.properties).toBeUndefined();
+    expect(snapshot.tree?.children[0].id).toBe('1');
+    expect(JSON.stringify(snapshot).length).toBeLessThanOrEqual(MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS);
+  });
+
+  it('strips runtime state before properties when the complete hierarchy envelope overflows', () => {
+    class StateHeavyComponent {}
+
+    const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
+    delegate.onElementCreated(1, 'layout');
+    delegate.onElementBecameRoot(1);
+    const element = makeRenderedElement(1, 'layout', {
+      first: 'a'.repeat(50_000),
+      fourth: 'd'.repeat(50_000),
+      second: 'b'.repeat(50_000),
+      third: 'c'.repeat(50_000),
+    });
+    const componentInstance = new StateHeavyComponent() as unknown as IComponent;
+    Object.defineProperty(componentInstance, 'state', {
+      configurable: true,
+      enumerable: true,
+      value: { payload: 's'.repeat(40_900) },
+    });
+    const component = makeVirtualNode('state-heavy', { component: componentInstance });
+    component.componentViewModel = { payload: 'p'.repeat(23_000) };
+    const elementNode = makeVirtualNode('layout', { element });
+    setVirtualChildren(component, [elementNode]);
+
+    const snapshot = delegate.getDebugSnapshot(
+      makeHierarchyRenderer([element], component),
+      MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS,
+      () => ({ componentToken: 'a'.repeat(32), snapshotRevision: 3 }),
+    );
+
+    expect(snapshot.tree?.component?.state).toBeUndefined();
+    expect(String(snapshot.tree?.component?.properties?.payload).length).toBe(23_000);
+    expect(snapshot.tree?.component?.propertyEdits?.payload).toEqual({
+      componentToken: 'a'.repeat(32),
+      snapshotRevision: 3,
+    });
     expect(snapshot.tree?.children[0].id).toBe('1');
     expect(JSON.stringify(snapshot).length).toBeLessThanOrEqual(MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS);
   });
@@ -1112,9 +1510,9 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
     delegate.onElementDestroyed(2);
     rootNode.children.push(staleChild);
     staleChild.parent = rootNode;
-    const getElementForId = jasmine.createSpy('getElementForId').and.callFake((id: number) =>
-      makeRenderedElement(id, id === 1 ? 'layout' : 'label', {}),
-    );
+    const getElementForId = jasmine
+      .createSpy('getElementForId')
+      .and.callFake((id: number) => makeRenderedElement(id, id === 1 ? 'layout' : 'label', {}));
     const renderer = { getElementForId } as unknown as IRenderer;
 
     const snapshot = delegate.getDebugSnapshot(renderer, MAX_WEB_DEBUGGER_SERIALIZED_CHARACTERS);
@@ -1211,9 +1609,9 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
       new Array<WebValdiLayout>(20_000).fill(staleNode),
       () => indexedReads++,
     );
-    const getElementForId = jasmine.createSpy('getElementForId').and.callFake((id: number) =>
-      makeRenderedElement(id, 'layout', {}),
-    );
+    const getElementForId = jasmine
+      .createSpy('getElementForId')
+      .and.callFake((id: number) => makeRenderedElement(id, 'layout', {}));
 
     const snapshot = delegate.getDebugSnapshot(
       { getElementForId } as unknown as IRenderer,
@@ -1239,10 +1637,7 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
     const staleNode = getBackingNode(delegate, 3)!;
     delegate.onElementDestroyed(3);
     staleNode.parent = rootNode;
-    const renderer = makeRenderer([
-      makeRenderedElement(1, 'layout', {}),
-      makeRenderedElement(2, 'layout', {}),
-    ]);
+    const renderer = makeRenderer([makeRenderedElement(1, 'layout', {}), makeRenderedElement(2, 'layout', {})]);
     let atCapReads = 0;
     rootNode.children = observeIndexedChildReads(
       [...new Array<WebValdiLayout>(999).fill(staleNode), liveNode],
@@ -1322,16 +1717,11 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
       },
     });
 
-    const snapshot = captureSnapshot(delegate, [
-      makeRenderedElement(1, 'layout', { items: inspectedArray }),
-    ]);
+    const snapshot = captureSnapshot(delegate, [makeRenderedElement(1, 'layout', { items: inspectedArray })]);
     const debugItems = snapshot.tree?.element?.attributes.items as unknown[];
 
     expect(getterCalls).toBe(0);
-    expect(inspectedProperties).toEqual([
-      'length',
-      ...Array.from({ length: 50 }, (_value, index) => String(index)),
-    ]);
+    expect(inspectedProperties).toEqual(['length', ...Array.from({ length: 50 }, (_value, index) => String(index))]);
     expect(inspectedProperties).not.toContain('50');
     expect(debugItems[0]).toBe('<accessor/>');
     expect(debugItems[49]).toBe('<accessor/>');
@@ -1382,9 +1772,7 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
     const delegate = new ValdiWebRendererDelegate(dom.createElement('main'));
     delegate.onElementCreated(1, 'layout');
     delegate.onElementBecameRoot(1);
-    const renderer = makeRenderer([
-      makeRenderedElement(1, 'layout', { payload: 'x'.repeat(100_000) }),
-    ]);
+    const renderer = makeRenderer([makeRenderedElement(1, 'layout', { payload: 'x'.repeat(100_000) })]);
 
     const snapshot = delegate.getDebugSnapshot(renderer, 8_192);
 
@@ -1462,9 +1850,7 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
       },
     };
 
-    const snapshot = captureSnapshot(delegate, [
-      makeRenderedElement(1, 'layout', { nested, properties }),
-    ]);
+    const snapshot = captureSnapshot(delegate, [makeRenderedElement(1, 'layout', { nested, properties })]);
     const debugAttributes = snapshot.tree?.element?.attributes ?? {};
     const debugProperties = debugAttributes.properties as Record<string, unknown>;
 
@@ -1508,9 +1894,7 @@ describe('ValdiWebRendererDelegate debugger adapter', () => {
       },
     });
     const getElementForId = jasmine.createSpy('getElementForId').and.returnValue(renderedElement);
-    const getRootVirtualNode = jasmine
-      .createSpy('getRootVirtualNode')
-      .and.returnValue(adversarialRootVirtualNode);
+    const getRootVirtualNode = jasmine.createSpy('getRootVirtualNode').and.returnValue(adversarialRootVirtualNode);
     const renderer = { getElementForId, getRootVirtualNode } as unknown as IRenderer;
 
     delegate.onElementCreated(1, 'layout');


### PR DESCRIPTION
## Description

Adds bounded runtime-state capture and browsing as the final core debugger-stack capability.

- Captures exact component-instance state through own data descriptors under hierarchy-wide byte, projection, and reflection budgets.
- Strictly parses escaped web JSON while keeping structurally untrusted native state escaped and raw-only.
- Uses collision-free row identities, fail-closed Inspect targeting, and focus-safe refresh deferral.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation improvement
- [ ] Performance optimization
- [x] Test improvement
- [x] Other (new debugger capability)

## Testing
- [ ] Tests pass locally (`bazel test //...`)
- [x] Added/updated tests for changes (if applicable)
- [ ] Tested on multiple platforms (iOS/Android/Web/macOS as applicable)
- [ ] Manual testing performed (describe below)

### Testing Details
- Runtime State passed 21/21; integrated DevTools passed 66/66; combined coverage passed 87/87.
- Full CLI passed 436/436 and the production build passed.
- Focused `//src/valdi_modules/src/valdi/web_renderer:test` passed after 11,519 actions.
- `bazel query //...` passed.
- The broad Valdi suite reproduced the established 12 unrelated failures; all runtime-state and property-edit specs passed.
- Two final independent audits were clean at frozen patch fingerprint `9607de6e04b2d332e1573ae450488f7f1bfa5274633e4a432e00c89e96618fd0`.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in description)
- [x] Commit messages follow [conventional format](../CONTRIBUTING.md#commit-messages)
- [x] No secrets, API keys, or internal URLs included

## Related Issues
Relates to #154

## Additional Context
Stack 22/22. Stacked on #174 (`bjd/debugger-component-property-edit`). Review this PR as the single incremental commit `8334cd63` against that base; do not merge it before its parent.