### PR TITLE
Cooperative termination mode: drain teardown instead of aborting

### DIFF
--- a/valdi/src/valdi/runtime/JavaScript/JavaScriptRuntime.cpp
+++ b/valdi/src/valdi/runtime/JavaScript/JavaScriptRuntime.cpp
@@ -344,6 +344,11 @@ void JavaScriptRuntime::postInit() {
         auto runtimeTweaks = listener->getRuntimeTweaks();
         if (runtimeTweaks != nullptr) {
             _dispatchQueue->setDisableSyncCallsInCallingThread(runtimeTweaks->disableSyncCallsInCallingThread());
+            // Pull the termination mode here too: worker runtimes are created fresh (runtimeCreateWorker)
+            // and only inherit the host's listener, not its pushed tweaks, so Runtime::setRuntimeTweaks
+            // (which targets the host runtime) never reaches them. Reading it at postInit — after the
+            // worker's listener is set — lets a worker honor an aggressive-termination override.
+            setCooperativeTermination(runtimeTweaks->useCooperativeTermination());
         }
     }
 }
@@ -4058,7 +4063,16 @@ DispatchFunction JavaScriptRuntime::makeJsThreadDispatchFunction(Ref<Context>&& 
                                                                  JavaScriptThreadTask&& jsTask) {
     SC_ASSERT(ownerContext != nullptr);
     return [this, retainedContext = RetainedContext(std::move(ownerContext)), jsTask = std::move(jsTask)]() {
-        if (_isDisposed || _javaScriptContext == nullptr || !_running) {
+        if (_javaScriptContext == nullptr || !_running) {
+            return;
+        }
+        // Aggressive teardown flips _isDisposed from another thread and only queues teardownOnJsThread,
+        // so skipping disposed work here can silently drop an in-flight bridge call and crash its caller
+        // on the undefined result. Cooperative mode instead drains: in-flight and already-queued work
+        // runs (the context is still alive, since teardownOnJsThread is serialized after it on this
+        // serial queue), then teardown destroys the context and later calls are refused by the check
+        // above.
+        if (_isDisposed && !_cooperativeTermination) {
             return;
         }
 

--- a/valdi/src/valdi/runtime/JavaScript/JavaScriptRuntime.hpp
+++ b/valdi/src/valdi/runtime/JavaScript/JavaScriptRuntime.hpp
@@ -223,6 +223,22 @@ public:
         _resolutionTeardownDegradeEnabled = enabled;
     }
 
+    // Kept in sync with VALDI_USE_COOPERATIVE_TERMINATION by Runtime::setRuntimeTweaks. Read by
+    // JavaScriptWorker::terminate()/dtor (skip forced execution termination) and by
+    // makeJsThreadDispatchFunction (drain in-flight/queued work during teardown instead of skipping it).
+    void setCooperativeTermination(bool enabled) {
+        _cooperativeTermination = enabled;
+    }
+    bool cooperativeTermination() const {
+        return _cooperativeTermination;
+    }
+
+    // Test-only: enter/leave the disposed-but-context-alive teardown window without running teardown,
+    // so the dispatch guard's cooperative-drain vs aggressive-skip behavior can be tested deterministically.
+    void setDisposedForTesting(bool disposed) {
+        _isDisposed = disposed;
+    }
+
     // True when ANR diagnostics are on and the caller is on this runtime's JS thread. Guards the
     // native-call activity writes so worker threads never touch the JS thread's slot.
     bool anrDiagnosticsActiveOnJsThread();
@@ -428,6 +444,9 @@ private:
     // to gate the teardown degrade; held here (not fetched via the listener) so it survives teardown.
     // Defaults to on.
     std::atomic<bool> _resolutionTeardownDegradeEnabled = true;
+    // Mirror of VALDI_USE_COOPERATIVE_TERMINATION (see setCooperativeTermination). Held here
+    // so JavaScriptWorker can read it independent of the listener. Defaults to cooperative.
+    std::atomic<bool> _cooperativeTermination = true;
     std::atomic<ContextId> _lastDispatchedContextId;
     // ANR attribution diagnostics, gated by the VALDI_ENABLE_MODULE_LOAD_DIAGNOSTICS COF key (key
     // name kept from the earlier module-load diagnostics for config continuity). The mutex guards

--- a/valdi/src/valdi/runtime/JavaScript/JavaScriptWorker.cpp
+++ b/valdi/src/valdi/runtime/JavaScript/JavaScriptWorker.cpp
@@ -15,7 +15,10 @@ JavaScriptWorker::JavaScriptWorker(Ref<JavaScriptRuntime> hostRuntime,
 
 JavaScriptWorker::~JavaScriptWorker() {
     VALDI_INFO(_workerRuntime->getLogger(), "Destroying JS Worker with URL: {}", _url);
-    _workerRuntime->requestExecutionTermination();
+    // Cooperative mode drains the worker instead of forcing execution termination; see terminate().
+    if (!_workerRuntime->cooperativeTermination()) {
+        _workerRuntime->requestExecutionTermination();
+    }
     _workerRuntime->requestFullTeardown();
 }
 
@@ -75,7 +78,13 @@ void JavaScriptWorker::terminate() {
         _hostOnMessage = nullptr;
     }
 
-    _workerRuntime->requestExecutionTermination();
+    // Aggressive termination forces the JS engine to abort mid-execution (even a frozen worker), which
+    // tears down in-flight bridge calls and causes teardown-race side effects. In cooperative mode we
+    // skip the forced abort: the worker drains its current work on the serial JS queue and the
+    // async-queued teardown then runs cleanly after it (matching self.close()).
+    if (!_workerRuntime->cooperativeTermination()) {
+        _workerRuntime->requestExecutionTermination();
+    }
     _workerRuntime->requestFullTeardown();
 }
 

--- a/valdi/src/valdi/runtime/Runtime.cpp
+++ b/valdi/src/valdi/runtime/Runtime.cpp
@@ -753,6 +753,11 @@ void Runtime::setRuntimeTweaks(const Ref<ValdiRuntimeTweaks>& runtimeTweaks) {
         // during teardown, when the listener (this Runtime) is no longer reachable.
         _javaScriptRuntime->setResolutionTeardownDegradeEnabled(
             runtimeTweaks != nullptr ? runtimeTweaks->enableResolutionTeardownDegrade() : true);
+        // Same for the termination mode. This reaches the host runtime; worker runtimes pull it
+        // themselves in JavaScriptRuntime::postInit (they inherit the host's listener, not this
+        // pushed tweak), so a host override reaches both.
+        _javaScriptRuntime->setCooperativeTermination(
+            runtimeTweaks != nullptr ? runtimeTweaks->useCooperativeTermination() : true);
     }
 }
 

--- a/valdi/src/valdi/runtime/ValdiRuntimeTweaks.cpp
+++ b/valdi/src/valdi/runtime/ValdiRuntimeTweaks.cpp
@@ -118,6 +118,12 @@ bool ValdiRuntimeTweaks::enableResolutionTeardownDegrade() const {
     return _tweakValueProvider->getBool(configKey, true);
 }
 
+bool ValdiRuntimeTweaks::useCooperativeTermination() const {
+    auto configKey =
+        StringCache::getGlobal().makeStringFromLiteral(std::string_view("VALDI_USE_COOPERATIVE_TERMINATION"));
+    return _tweakValueProvider->getBool(configKey, true);
+}
+
 bool ValdiRuntimeTweaks::applyManagedChildFramePadding() const {
     auto configKey =
         StringCache::getGlobal().makeStringFromLiteral(std::string_view("VALDI_MANAGES_CHILD_FRAME_PADDING_ENABLED"));

--- a/valdi/src/valdi/runtime/ValdiRuntimeTweaks.hpp
+++ b/valdi/src/valdi/runtime/ValdiRuntimeTweaks.hpp
@@ -38,6 +38,11 @@ public:
     // kResolutionSkippedDuringTeardownErrorCode so a marshalling boundary can degrade to a no-op
     // instead of raising an uncatchable error. Set false to restore the raising behavior.
     bool enableResolutionTeardownDegrade() const;
+    // When true (default), teardown drains cooperatively: worker terminate() skips forced execution
+    // termination, and a disposed runtime lets in-flight/queued JS-thread work finish before teardown
+    // (avoids the silent-skip that crashes an in-flight bridge call). Set false for aggressive
+    // termination that stops even frozen JS, at the cost of teardown-race side effects.
+    bool useCooperativeTermination() const;
     bool applyManagedChildFramePadding() const;
     bool disableHitTestSyncDeadline() const;
     // True when VALDI_MAX_VIEW_OPERATIONS_PROCESSING_TIME > 0 (throttling enabled). Gates top-down move order in TS.

--- a/valdi/test/integration/Runtime_tests.cpp
+++ b/valdi/test/integration/Runtime_tests.cpp
@@ -6991,6 +6991,39 @@ TEST_P(RuntimeFixture, pushModuleToMarshallerStillErrorsForMissingModuleWhenRunt
         << "A genuine resolution failure must not be labeled as a teardown skip: " << error.toString();
 }
 
+// Cooperative termination mode (the default) must DRAIN: a task dispatched while the runtime is
+// disposed but its context is still alive still runs, rather than being silently skipped (a skip
+// drops an in-flight bridge call and crashes its caller on the undefined result). Aggressive mode
+// skips it (the pre-fix host-teardown behavior). Uses setDisposedForTesting to hold the
+// disposed-but-context-alive window deterministically without running teardown.
+TEST_P(RuntimeFixture, cooperativeTeardownDrainsInFlightWorkAggressiveSkipsIt) {
+    auto* javaScriptRuntime = wrapper.runtime->getJavaScriptRuntime();
+
+    // Cooperative (default): disposed-but-context-alive work runs.
+    {
+        bool ran = false;
+        javaScriptRuntime->dispatchSynchronouslyOnJsThread([&](auto&) {
+            javaScriptRuntime->setDisposedForTesting(true);
+            javaScriptRuntime->dispatchSynchronouslyOnJsThread([&](auto&) { ran = true; });
+            javaScriptRuntime->setDisposedForTesting(false);
+        });
+        EXPECT_TRUE(ran) << "cooperative mode must drain in-flight work during the teardown window";
+    }
+
+    // Aggressive: disposed work is skipped (restore cooperative afterward for clean fixture teardown).
+    javaScriptRuntime->setCooperativeTermination(false);
+    {
+        bool ran = false;
+        javaScriptRuntime->dispatchSynchronouslyOnJsThread([&](auto&) {
+            javaScriptRuntime->setDisposedForTesting(true);
+            javaScriptRuntime->dispatchSynchronouslyOnJsThread([&](auto&) { ran = true; });
+            javaScriptRuntime->setDisposedForTesting(false);
+        });
+        EXPECT_FALSE(ran) << "aggressive mode skips disposed work";
+    }
+    javaScriptRuntime->setCooperativeTermination(true);
+}
+
 // Verifies that a sync JS call from the main thread triggers the assertion when the module has
 // async_strict_mode and the function is not annotated with @AllowSyncCall. Uses a dedicated
 // test_async_strict module (async_strict_mode=True) so the main test module can stay non-strict.


### PR DESCRIPTION
Draft for discussion, not for merge. Updated to the cooperative-mode approach (replaces the earlier dispatch-guard version on this branch).

## Problem
Aggressive teardown flips `_isDisposed` from another thread and force-terminates JS execution, aborting in-flight work and racing the JS thread. That's a large blast radius of teardown crashes / UB, and most of it is on host/session-scoped runtimes torn down on logout / scope-exit (not just workers).

## Approach — a configurable mode, default cooperative
One flag on the runtime; cooperative mode drains instead of aborting:
- **Host:** `makeJsThreadDispatchFunction` no longer skips work just because `_isDisposed` is set. In-flight and already-queued JS-thread work runs (the context is still alive, since teardown is serialized after it on the serial queue), then teardown destroys the context and later calls are refused by the liveness check. This effectively restores the pre-aggressive ordering.
- **Worker:** `terminate()`/dtor skip `requestExecutionTermination()` and drain like `self.close()`.

Set the flag false for aggressive termination (stops even frozen JS, at the cost of the teardown races), so the aggressive path stays available and can be rolled out again safely once the root cause is fully addressed.

## Open question
This mitigates by reverting to cooperative behavior. The known trade is the original one: cooperative can't force-stop a genuinely frozen JS worker (it drains, so a busy loop won't tear down). A bounded wait-then-escalate would preserve the frozen-JS guarantee while keeping well-behaved teardown safe. Feedback welcome on whether to build that here or in the deeper fix.

## Tests
`bzl test //valdi:test_integration`: new `cooperativeTeardownDrainsInFlightWorkAggressiveSkipsIt` (all 4 JS engines) asserts cooperative drains in-flight work and aggressive skips it; existing teardown and worker-termination tests stay green.
