### PR TITLE
fix: flush stdout writes in ConsoleLogger::writeDirect

### DIFF
--- a/valdi/test/runtime/ConsoleLogger_tests.cpp
+++ b/valdi/test/runtime/ConsoleLogger_tests.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include "valdi_core/cpp/Utils/ConsoleLogger.hpp"
+#include <ostream>
+#include <streambuf>
+#include <string>
+
+using namespace Valdi;
+
+namespace ValdiTest {
+
+#if !defined(SC_IOS) && !defined(__ANDROID__)
+
+namespace {
+
+class BufferedSink : public std::streambuf {
+public:
+    std::string delivered;
+
+protected:
+    int overflow(int ch) override {
+        if (ch != traits_type::eof()) {
+            _pending.push_back(static_cast<char>(ch));
+        }
+        return ch;
+    }
+
+    int sync() override {
+        delivered += _pending;
+        _pending.clear();
+        return 0;
+    }
+
+    std::streamsize xsputn(const char* s, std::streamsize count) override {
+        _pending.append(s, static_cast<size_t>(count));
+        return count;
+    }
+
+private:
+    std::string _pending;
+};
+
+} // namespace
+
+TEST(ConsoleLogger, writeDirectReachesTheDeviceBeforeReturning) {
+    BufferedSink sink;
+    std::ostream stream(&sink);
+    ConsoleLogger logger(stream);
+
+    logger.writeDirect("hello\n");
+
+    ASSERT_EQ("hello\n", sink.delivered);
+}
+
+TEST(ConsoleLogger, logReachesTheDeviceBeforeReturning) {
+    BufferedSink sink;
+    std::ostream stream(&sink);
+    ConsoleLogger logger(stream);
+
+    logger.log(LogTypeError, "boom");
+
+    ASSERT_NE(std::string::npos, sink.delivered.find("boom"));
+}
+
+#endif
+
+} // namespace ValdiTest

--- a/valdi_core/src/valdi_core/cpp/Utils/ConsoleLogger.cpp
+++ b/valdi_core/src/valdi_core/cpp/Utils/ConsoleLogger.cpp
@@ -134,7 +134,7 @@ void ConsoleLogger::writeDirect(std::string_view message) {
 #else
     auto t = message.size();
     (void)t;
-    _stream << message;
+    _stream << message << std::flush;
 #endif
 }
 


### PR DESCRIPTION
## Description

Flush stdout writes in `ConsoleLogger::writeDirect`

`writeDirect` never flushes. It backs `process.stdout.write` in CLI apps, and `std::cout` is fully buffered on anything that isn't a TTY, so piped output arrives in 4 KB bursts and a CLI killed by a signal loses it entirely. SIGTERM and SIGINT aren't handled, so a long-running CLI never flushes at all.

`log()` already flushes via `std::endl` so it is reliable but the raw one isn't. `log` also prefixes lines with text like:

```
[0.011: INFO] [JS]
```

which is noise for an end user. Calling `process.stdout.write` from my logger lets me skip that and keep the formatted lines I actually want to show.

My usecase: a long-running daemon built as a `valdi_cli_application`, logging through `process.stdout.write`.
Every short-lived command that just does something and exits worked.
The daemon printed nothing. Same binary, output redirected to a file, killed after five seconds: zero bytes, no log lines. Re-running the identical command on a pty and reading while the process was still alive produced all of it. Terminal fine, redirected silent.

That is line buffering on a TTY against full buffering on a file, with no flush and no normal exit to trigger one. Under systemd it means `journalctl` stays empty until 4 KB accumulates, and `systemctl stop` discards whatever is pending.

Example:

```ts
import { beginKeepAlive } from 'valdi_core/src/utils/KeepAliveCallback';

declare const process: { stdout: { write(text: string): boolean } };

process.stdout.write('this line never arrives\n');
beginKeepAlive();
```

steps:

```
cli_example_app             # on a terminal it prints immediately

cli_example_app > out.txt &
pid=$!
sleep 2
cat out.txt                 # empty, though the write call has returned
kill $pid
cat out.txt                 # still empty, the buffered bytes died with the process
```

The keep-alive is what makes it reproducible. A CLI that exits on its own flushes stdio on the way out, so every existing example prints fine even when redirected. It needs two things: stdout that isn't a TTY, and a process that doesn't exit normally.

Limitations:

- One write per call instead of one per 4 KB. A CLI emitting large output a line at a time now pays a syscall per line.
- A flush on a pipe blocks once the pipe buffer is full, which happens sooner than waiting for a 4 KB buffer to fill. That matters for a process logging from a latency-sensitive thread to a slow reader.

Working around them:

```ts
// one syscall per line
for (const line of lines) process.stdout.write(line + '\n');

// one syscall
process.stdout.write(lines.join('\n') + '\n');
```

Batching in JS trades libc's invisible 4 KB buffer for one the caller sizes and flushes on its own schedule. Every `process.stdout.write` crosses the JS to native bridge, which costs more than the `write` it triggers, so anyone doing per-line writes for bulk output already has ~a performance problem~ room for improvement. Batching makes them faster than they were before this change.


## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation improvement
- [ ] Performance optimization
- [ ] Test improvement
- [ ] Other (please describe)

## Testing
- [x] Tests pass locally (`bazel test //...`)
- [x] Added/updated tests for changes (if applicable)
- [x] Tested on multiple platforms (iOS/Android/Web/macOS as applicable)
- [x] Manual testing performed (describe below)

### Testing Details
<!-- Describe the testing you performed -->

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in description)
- [x] Commit messages follow [conventional format](../CONTRIBUTING.md#commit-messages)
- [x] No secrets, API keys, or internal URLs included

## Related Issues
<!-- Link related issues using: Closes #(issue), Fixes #(issue), Relates to #(issue) -->

## Additional Context
<!-- Add any other context, screenshots, or information that would help reviewers -->
