### PR TITLE
Demonstrate bridge-function resolution teardown behavior in Hello World

### DIFF
--- a/apps/helloworld/TEARDOWN_REPRO.md
+++ b/apps/helloworld/TEARDOWN_REPRO.md
@@ -1,0 +1,57 @@
+# Bridge-function resolution teardown repro
+
+A minimal, self-contained demonstration of what happens when a native → JS **bridge function is
+resolved while the JS runtime is being torn down** (the situation a Valdi session hits on logout /
+account switch), wired into the Hello World app (iOS).
+
+## The behavior
+
+`+[SCValdiBridgeFunction functionWithJSRuntime:]` resolves a generated bridge function by pushing
+its module onto a marshaller. If the JS runtime is disposed between a call being queued and
+executed, the JS-thread task that would populate the marshaller is skipped.
+
+- **Without the resolution-teardown degrade**, the marshaller is left empty and
+  `SCValdiMarshallerCheck` raises an ObjC `SCValdiError` NSException. Because the resolver is reached
+  from a Swift (or unguarded ObjC) frame, the exception is uncatchable and the process aborts
+  (SIGABRT).
+- **With the degrade** (`VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE`, on by default), the skipped task
+  is stamped with a distinguishable teardown error code; `functionWithJSRuntime:` recognizes it and
+  returns a non-nil **no-op** bridge function so the dying session unwinds quietly instead of
+  aborting.
+
+## What this repro does (`src/ios/SCValdiTeardownRepro.mm`)
+
+1. Stands up an **isolated** `SCValdiRuntimeManager` (so teardown doesn't kill the app's own UI).
+2. Captures the main runtime's `jsRuntime` strongly, so the disposed runtime stays addressable.
+3. Forces `VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE` to a known state on that runtime by injecting a
+   fixed `ITweakValueProvider` (the value is cached on the JS runtime before teardown detaches the
+   listener, so it survives disposal).
+4. On a background queue (resolution on the main thread is forbidden by `async_strict_mode`):
+   - resolves the probe on the **live** runtime — succeeds (sanity, logged);
+   - drops the manager (`manager = nil`) → dealloc → `fullTeardown` → runtime disposed;
+   - resolves the probe **again**, and either degrades (no crash) or aborts, depending on the mode.
+
+The probe is a trivial exported function, `makeTeardownProbe` in
+`src/valdi/teardown_probe/src/TeardownReproProbe.ts`, which codegen turns into the bridge-function
+class `SCCTeardownProbeMakeTeardownProbe` (only its resolution is exercised; the body never runs).
+
+## How to trigger
+
+Run the Hello World app on iOS. Two debug-only buttons at the bottom of the screen:
+
+- **"✅ Resolve after teardown (degrade ON — no crash)"** (accessibilityId `teardown-degrade-button`)
+  — the shipped default. Resolution after teardown returns a no-op function; the final `NSLog`
+  (`degrade ON: resolved after teardown without crashing`) prints and the app keeps running.
+- **"⚠️ Resolve after teardown (degrade OFF — SIGABRT)"** (accessibilityId `teardown-crash-button`)
+  — disables the kill switch first. The app aborts within a second; the crash matches the original
+  teardown crash (`SCValdiErrorThrowWithStacktrace` → `SCValdiMarshallerCppCheck` →
+  `-[SCValdiJSRuntimeImpl pushModuleAtPath:inMarshaller:]` → `+[…Probe functionWithJSRuntime:]`).
+
+Android and web wire both buttons to no-ops — this behavior is iOS-specific.
+
+## Note
+
+This demonstrates the resolution-teardown degrade as a pair: the crash it removes (degrade off) and
+the graceful unwind it provides (degrade on). It exercises the **raising**
+`functionWithJSRuntime:` entry point; the non-raising `resolve(jsRuntime:)` resolver instead reports
+teardown as `nil` + `NSError` so its adopters can run their own degrade path.

--- a/apps/helloworld/TEARDOWN_REPRO.md
+++ b/apps/helloworld/TEARDOWN_REPRO.md
@@ -1,57 +1,73 @@
-# Bridge-function resolution teardown repro
+# Bridge-function teardown repro
 
-A minimal, self-contained demonstration of what happens when a native → JS **bridge function is
-resolved while the JS runtime is being torn down** (the situation a Valdi session hits on logout /
-account switch), wired into the Hello World app (iOS).
+A minimal, self-contained demonstration of what happens when a native → JS **bridge crossing races
+JS-runtime teardown** (the situation a Valdi session hits on logout / account switch), wired into the
+Hello World app (iOS). It covers both crossings that crash — **resolution** and **invocation** — and
+the resolution-teardown degrade that sits between them.
+
+## Which crash each button reproduces
+
+Three debug-only buttons at the bottom of the Hello World screen. Each stands up an **isolated**
+`SCValdiRuntimeManager`, disposes it, and then crosses the bridge on the disposed runtime off the
+main thread (`async_strict_mode` forbids resolution on the main thread):
+
+| Button (accessibilityId) | Crossing | Degrade | Outcome |
+|---|---|---|---|
+| ✅ `teardown-degrade-button` | resolution | on (default) | **No crash** — resolution returns a no-op function and unwinds quietly. |
+| ⚠️ `teardown-crash-button` | resolution | off (kill switch) | **SIGABRT** — the raising resolver throws an uncatchable `SCValdiError` below the calling frame. |
+| 💥 `teardown-invocation-button` | invocation | on (default) | **SIGABRT** — resolution degrades to a no-op, but **invoking** it returns a null value in a `_Nonnull` slot; passing that null to a non-null-requiring API (`+[NSURL fileURLWithPath:]`) raises `NSInvalidArgumentException`. |
+
+Android and web wire all three to no-ops — this behavior is iOS-specific.
 
 ## The behavior
 
-`+[SCValdiBridgeFunction functionWithJSRuntime:]` resolves a generated bridge function by pushing
-its module onto a marshaller. If the JS runtime is disposed between a call being queued and
-executed, the JS-thread task that would populate the marshaller is skipped.
+### Resolution (buttons 1 & 2)
 
-- **Without the resolution-teardown degrade**, the marshaller is left empty and
-  `SCValdiMarshallerCheck` raises an ObjC `SCValdiError` NSException. Because the resolver is reached
-  from a Swift (or unguarded ObjC) frame, the exception is uncatchable and the process aborts
-  (SIGABRT).
-- **With the degrade** (`VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE`, on by default), the skipped task
-  is stamped with a distinguishable teardown error code; `functionWithJSRuntime:` recognizes it and
-  returns a non-nil **no-op** bridge function so the dying session unwinds quietly instead of
-  aborting.
+`+[SCValdiBridgeFunction functionWithJSRuntime:]` resolves a generated bridge function by pushing its
+module onto a marshaller. If the JS runtime is disposed between a call being queued and executed, the
+JS-thread task that would populate the marshaller is skipped.
 
-## What this repro does (`src/ios/SCValdiTeardownRepro.mm`)
+- **Without the degrade** (`VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE` off), the marshaller is left
+  empty and `SCValdiMarshallerCheck` raises an ObjC `SCValdiError` NSException. Reached from a Swift
+  (or unguarded ObjC) frame, the exception is uncatchable and the process aborts (**SIGABRT**).
+- **With the degrade** (on by default), the skipped task is stamped with a distinguishable teardown
+  error code; `functionWithJSRuntime:` recognizes it and returns a non-nil **no-op** bridge function
+  so the dying session unwinds quietly instead of aborting.
 
-1. Stands up an **isolated** `SCValdiRuntimeManager` (so teardown doesn't kill the app's own UI).
-2. Captures the main runtime's `jsRuntime` strongly, so the disposed runtime stays addressable.
-3. Forces `VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE` to a known state on that runtime by injecting a
-   fixed `ITweakValueProvider` (the value is cached on the JS runtime before teardown detaches the
-   listener, so it survives disposal).
-4. On a background queue (resolution on the main thread is forbidden by `async_strict_mode`):
-   - resolves the probe on the **live** runtime — succeeds (sanity, logged);
-   - drops the manager (`manager = nil`) → dealloc → `fullTeardown` → runtime disposed;
-   - resolves the probe **again**, and either degrades (no crash) or aborts, depending on the mode.
+### Invocation (button 3)
 
-The probe is a trivial exported function, `makeTeardownProbe` in
-`src/valdi/teardown_probe/src/TeardownReproProbe.ts`, which codegen turns into the bridge-function
-class `SCCTeardownProbeMakeTeardownProbe` (only its resolution is exercised; the body never runs).
+The degrade prevents the resolution abort, but the no-op function it returns is still `_Nonnull` and
+still callable. **Invoking** it (`-[…GetTeardownPath getTeardownPath]` → the no-op `callBlock`)
+returns a **null value** — and the generated return type is `_Nonnull` (here `NSString * _Nonnull`),
+so callers trust it is non-null. Passing that null to an API with a non-null precondition,
+`+[NSURL fileURLWithPath:]`, raises `NSInvalidArgumentException` (`nil string parameter`) and aborts
+(**SIGABRT**).
+
+This is the invocation-teardown nil-in-`nonnull` crash: the degrade turned a resolution abort into a
+null value that flows past the type system and detonates in whatever downstream code trusts the
+non-null contract. (The exact downstream varies — a nonnull-arg API like the `NSURL` case here, a
+value the caller force-unwraps, etc.)
+
+## What this repro does
+
+- `src/valdi/teardown_probe/src/TeardownReproProbe.ts` — an `@ExportFunction makeTeardownProbe`
+  returning an `@ExportProxy` (for the resolution buttons) and an `@ExportFunction getTeardownPath`
+  returning a `string` (for the invocation button), built with `async_strict_mode` so codegen emits
+  the `SCValdiBridgeFunction` subclasses. The bodies never run — only resolution/invocation are
+  exercised.
+- `src/ios/SCValdiTeardownRepro.mm` — owns the runtime lifecycle: creates the isolated runtime,
+  (for buttons 1 & 2) pins the degrade kill switch via an injected `ITweakValueProvider`, tears the
+  runtime down, and performs the resolution (buttons 1 & 2) or the invocation + nonnull-API use
+  (button 3).
 
 ## How to trigger
 
-Run the Hello World app on iOS. Two debug-only buttons at the bottom of the screen:
+Run the Hello World app on iOS and tap a button. Buttons 2 and 3 abort within a second; the crash
+matches the corresponding teardown signature:
+- button 2 (SIGABRT): `SCValdiErrorThrowWithStacktrace` → `SCValdiMarshallerCppCheck` →
+  `-[SCValdiJSRuntimeImpl pushModuleAtPath:inMarshaller:]` → `+[…MakeTeardownProbe functionWithJSRuntime:]`.
+- button 3 (SIGABRT): `NSInvalidArgumentException` (`nil string parameter`) ← `+[NSURL fileURLWithPath:]`
+  ← `+[SCValdiTeardownRepro reproduceInvocationCrash]`.
 
-- **"✅ Resolve after teardown (degrade ON — no crash)"** (accessibilityId `teardown-degrade-button`)
-  — the shipped default. Resolution after teardown returns a no-op function; the final `NSLog`
-  (`degrade ON: resolved after teardown without crashing`) prints and the app keeps running.
-- **"⚠️ Resolve after teardown (degrade OFF — SIGABRT)"** (accessibilityId `teardown-crash-button`)
-  — disables the kill switch first. The app aborts within a second; the crash matches the original
-  teardown crash (`SCValdiErrorThrowWithStacktrace` → `SCValdiMarshallerCppCheck` →
-  `-[SCValdiJSRuntimeImpl pushModuleAtPath:inMarshaller:]` → `+[…Probe functionWithJSRuntime:]`).
-
-Android and web wire both buttons to no-ops — this behavior is iOS-specific.
-
-## Note
-
-This demonstrates the resolution-teardown degrade as a pair: the crash it removes (degrade off) and
-the graceful unwind it provides (degrade on). It exercises the **raising**
-`functionWithJSRuntime:` entry point; the non-raising `resolve(jsRuntime:)` resolver instead reports
-teardown as `nil` + `NSError` so its adopters can run their own degrade path.
+Tools can trigger button 3 without a tap: launch with the env var
+`SIMCTL_CHILD_TEARDOWN_REPRO_AUTORUN=invocation` (debug-only hook; a normal launch does nothing).

--- a/apps/helloworld/src/android/MyNativeModuleFactory.kt
+++ b/apps/helloworld/src/android/MyNativeModuleFactory.kt
@@ -11,6 +11,15 @@ class MyNativeModuleFactory: NativeModuleModuleFactory() {
     override fun onLoadModule(): NativeModuleModule {
         return object: NativeModuleModule {
             override val APP_NAME = "Valdi Android"
+
+            // No-ops on Android: the teardown crash is iOS-specific.
+            override fun reproduceTeardownDegraded() {
+                android.util.Log.i("TeardownRepro", "no-op on Android")
+            }
+
+            override fun reproduceTeardownCrash() {
+                android.util.Log.i("TeardownRepro", "no-op on Android")
+            }
         }
     }
 }

--- a/apps/helloworld/src/android/MyNativeModuleFactory.kt
+++ b/apps/helloworld/src/android/MyNativeModuleFactory.kt
@@ -20,6 +20,10 @@ class MyNativeModuleFactory: NativeModuleModuleFactory() {
             override fun reproduceTeardownCrash() {
                 android.util.Log.i("TeardownRepro", "no-op on Android")
             }
+
+            override fun reproduceTeardownInvocationCrash() {
+                android.util.Log.i("TeardownRepro", "no-op on Android")
+            }
         }
     }
 }

--- a/apps/helloworld/src/ios/BUILD.bazel
+++ b/apps/helloworld/src/ios/BUILD.bazel
@@ -1,13 +1,41 @@
 objc_library(
     name = "native_module_ios",
-    srcs = glob([
-        "**/*.m",
-    ]),
+    srcs = [
+        "SCMyNativeModuleFactory.m",
+    ],
     hdrs = [],
     copts = ["-I."],
     target_compatible_with = ["@platforms//os:ios"],
     visibility = ["//visibility:public"],
     deps = [
         "//apps/helloworld/src/valdi/hello_world:hello_world_api_objc",
+        # Debug-only teardown repro harness (invoked from reproduceTeardown* native methods).
+        ":teardown_repro",
+    ],
+)
+
+# Debug-only harness for the bridge-function resolution teardown behavior. Kept in its own library
+# (not native_module_ios) because it depends on the teardown_probe module umbrella
+# (:SCCTeardownProbe) for the generated bridge-function class — which cannot be depended on from a
+# module's own ios_deps without a cycle.
+objc_library(
+    name = "teardown_repro",
+    srcs = [
+        "SCValdiTeardownRepro.mm",
+    ],
+    hdrs = [
+        "SCValdiTeardownRepro.h",
+    ],
+    copts = ["-I."],
+    target_compatible_with = ["@platforms//os:ios"],
+    visibility = ["//visibility:public"],
+    deps = [
+        # Provides the generated SCCTeardownProbeMakeTeardownProbe bridge-function class.
+        "//apps/helloworld/src/valdi/teardown_probe:SCCTeardownProbe",
+        # Runtime manager + ITweakValueProvider (to force the teardown-degrade kill switch).
+        "@valdi//valdi:valdi",
+        # StringBox / Value / Shared used by the injected tweak provider.
+        "@valdi//valdi_core",
+        "@valdi//valdi_core:valdi_core_objc",
     ],
 )

--- a/apps/helloworld/src/ios/BUILD.bazel
+++ b/apps/helloworld/src/ios/BUILD.bazel
@@ -30,7 +30,8 @@ objc_library(
     target_compatible_with = ["@platforms//os:ios"],
     visibility = ["//visibility:public"],
     deps = [
-        # Provides the generated SCCTeardownProbeMakeTeardownProbe bridge-function class.
+        # Provides the generated SCCTeardownProbeMakeTeardownProbe / SCCTeardownProbeGetTeardownPath
+        # bridge-function classes.
         "//apps/helloworld/src/valdi/teardown_probe:SCCTeardownProbe",
         # Runtime manager + ITweakValueProvider (to force the teardown-degrade kill switch).
         "@valdi//valdi:valdi",

--- a/apps/helloworld/src/ios/SCMyNativeModuleFactory.m
+++ b/apps/helloworld/src/ios/SCMyNativeModuleFactory.m
@@ -2,6 +2,9 @@
 #import <SCCHelloWorldTypes/SCCHelloWorldTypes.h>
 #import <Foundation/Foundation.h>
 
+#include <stdlib.h>
+#include <string.h>
+
 #import "SCValdiTeardownRepro.h"
 
 @interface SCMyNativeModule: NSObject<SCCHelloWorldNativeModuleModule>
@@ -32,6 +35,14 @@
     [SCValdiTeardownRepro reproduceWithDegradeEnabled:NO];
 }
 
+- (void)reproduceTeardownInvocationCrash
+{
+    // Invocation after teardown: resolution degrades to a no-op, invoking it returns a null value in
+    // a _Nonnull slot; passing it to a non-null-requiring API (+[NSURL fileURLWithPath:]) aborts
+    // (SIGABRT) — the invocation-teardown nil-in-nonnull crash.
+    [SCValdiTeardownRepro reproduceInvocationCrash];
+}
+
 @end
 
 @interface SCMyNativeModuleFactory : SCCHelloWorldNativeModuleModuleFactory
@@ -44,7 +55,17 @@ VALDI_REGISTER_MODULE()
 
 - (id<SCCHelloWorldNativeModuleModule>)onLoadModule
 {
-    return [SCMyNativeModule new];
+    SCMyNativeModule *module = [SCMyNativeModule new];
+    // Debug-only: let tools trigger a repro without a tap, via an env var (e.g.
+    // `SIMCTL_CHILD_TEARDOWN_REPRO_AUTORUN=invocation`). Shipping state is button-driven; with no env
+    // var set this does nothing.
+    const char *autorun = getenv("TEARDOWN_REPRO_AUTORUN");
+    if (autorun != NULL && strcmp(autorun, "invocation") == 0) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [module reproduceTeardownInvocationCrash];
+        });
+    }
+    return module;
 }
 
 @end

--- a/apps/helloworld/src/ios/SCMyNativeModuleFactory.m
+++ b/apps/helloworld/src/ios/SCMyNativeModuleFactory.m
@@ -2,6 +2,8 @@
 #import <SCCHelloWorldTypes/SCCHelloWorldTypes.h>
 #import <Foundation/Foundation.h>
 
+#import "SCValdiTeardownRepro.h"
+
 @interface SCMyNativeModule: NSObject<SCCHelloWorldNativeModuleModule>
 
 @end
@@ -16,6 +18,18 @@
 - (void)setAPP_NAME:(NSString *)appName
 {
 
+}
+
+- (void)reproduceTeardownDegraded
+{
+    // Degrade ON (shipped default): resolution after teardown returns a no-op, no crash.
+    [SCValdiTeardownRepro reproduceWithDegradeEnabled:YES];
+}
+
+- (void)reproduceTeardownCrash
+{
+    // Degrade OFF (kill switch disabled): resolution after teardown aborts the process (SIGABRT).
+    [SCValdiTeardownRepro reproduceWithDegradeEnabled:NO];
 }
 
 @end

--- a/apps/helloworld/src/ios/SCValdiTeardownRepro.h
+++ b/apps/helloworld/src/ios/SCValdiTeardownRepro.h
@@ -40,6 +40,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)reproduceWithDegradeEnabled:(BOOL)degradeEnabled;
 
+/**
+ Reproduces the bridge-function INVOCATION teardown crash. Resolves a bridge function on an isolated,
+ torn-down runtime (the resolution degrade, on by default, returns a no-op function), then INVOKES
+ it. The invocation returns a null value into a @c _Nonnull-typed return (a null @c NSString);
+ passing that null to an API with a non-null precondition (@c +[NSURL fileURLWithPath:]) raises
+ @c NSInvalidArgumentException and aborts (SIGABRT).
+
+ Distinct from @c reproduceWithDegradeEnabled: (the resolution path). Runs the invocation on a
+ background queue.
+ */
++ (void)reproduceInvocationCrash;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/apps/helloworld/src/ios/SCValdiTeardownRepro.h
+++ b/apps/helloworld/src/ios/SCValdiTeardownRepro.h
@@ -1,0 +1,45 @@
+//
+//  SCValdiTeardownRepro.h
+//  helloworld
+//
+//  Demonstrates the bridge-function resolution teardown behavior, both with and without the
+//  resolution-teardown degrade.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Debug-only harness that demonstrates what happens when a bridge function is resolved through the
+ raising path (+[SCValdiBridgeFunction functionWithJSRuntime:]) while its JS runtime is being torn
+ down — the situation a Valdi session hits on logout / account switch.
+
+ It stands up an isolated SCValdiRuntimeManager, captures the JS runtime, forces the
+ VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE kill switch to a known state on that runtime, tears the
+ runtime down, then resolves a probe bridge function off the main thread.
+
+ The isolated runtime is used so teardown can be triggered deterministically without touching the
+ app's shared runtime (which would kill the on-screen UI).
+
+ Two modes make the fix visible side by side:
+   - degrade ON (the shipped default): resolution after teardown returns a non-nil no-op function
+     and unwinds quietly — no crash.
+   - degrade OFF (kill switch disabled): resolution after teardown raises an uncatchable SCValdiError
+     below the calling frame and the process aborts (SIGABRT) — the original crash.
+ */
+@interface SCValdiTeardownRepro : NSObject
+
+/**
+ Resolves the probe bridge function after tearing its runtime down, with the resolution-teardown
+ degrade forced to @c degradeEnabled on the isolated runtime. Runs the resolution on a background
+ queue (async_strict_mode forbids resolution on the main thread).
+
+ With @c degradeEnabled == NO the resolution raises an uncaught SCValdiError and aborts the process
+ (SIGABRT). With @c degradeEnabled == YES it returns a no-op function and logs without crashing.
+ */
++ (void)reproduceWithDegradeEnabled:(BOOL)degradeEnabled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apps/helloworld/src/ios/SCValdiTeardownRepro.mm
+++ b/apps/helloworld/src/ios/SCValdiTeardownRepro.mm
@@ -109,4 +109,45 @@ class TeardownDegradeProvider : public Valdi::SharedPtrRefCountable, public Vald
     });
 }
 
++ (void)reproduceInvocationCrash
+{
+    // Isolated runtime so teardown can be forced without touching the app's shared runtime.
+    __block SCValdiRuntimeManager *manager = [SCValdiRuntimeManager new];
+    SCValdiRuntime *runtime = manager.mainRuntime;
+    id<SCValdiJSRuntime> jsRuntime = [runtime jsRuntime];
+    runtime = nil;
+
+    // No tweak provider: we WANT the resolution degrade at its shipped default (on). Resolution
+    // after teardown then returns a no-op function; INVOKING that no-op returns a null object, which
+    // is the invocation-teardown crash we want (not the resolution abort).
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        // Sanity on the live runtime: the probe resolves.
+        @try {
+            SCCTeardownProbeMakeTeardownProbe *live = [SCCTeardownProbeMakeTeardownProbe functionWithJSRuntime:jsRuntime];
+            NSLog(@"[TeardownRepro] invocation live resolve ok: %@", live);
+        } @catch (SCValdiError *error) {
+            NSLog(@"[TeardownRepro] invocation live resolve raised (probe module may not be bundled): %@", error.reason);
+        }
+
+        // Tear the runtime down.
+        manager = nil;
+
+        // Resolve (degrades to a no-op function) then invoke it. The invocation returns a null value
+        // in a _Nonnull-typed slot: a null NSString here (the codegen return type is
+        // `NSString * _Nonnull`, so callers trust it is non-null).
+        NSLog(@"[TeardownRepro] invocation: resolving + invoking after teardown...");
+        SCCTeardownProbeGetTeardownPath *fn = [SCCTeardownProbeGetTeardownPath functionWithJSRuntime:jsRuntime];
+        NSString *path = [fn getTeardownPath];
+        NSLog(@"[TeardownRepro] invocation: invoked; path=%@ (null on teardown), passing to a nonnull API...", path);
+
+        // Pass the null-in-_Nonnull string to an API with a non-null precondition. +[NSURL
+        // fileURLWithPath:] raises NSInvalidArgumentException on a nil path, aborting the process
+        // (SIGABRT). This is the invocation-teardown nil-in-nonnull crash: the degrade produced a null
+        // where downstream code trusts the non-null contract. No @try: the point is the crash.
+        NSURL *url = [NSURL fileURLWithPath:path];
+        NSLog(@"[TeardownRepro] invocation UNEXPECTED: built url without crashing: %@", url);
+        NSLog(@"[TeardownRepro] invocation UNEXPECTED: returned without crashing");
+    });
+}
+
 @end

--- a/apps/helloworld/src/ios/SCValdiTeardownRepro.mm
+++ b/apps/helloworld/src/ios/SCValdiTeardownRepro.mm
@@ -1,0 +1,112 @@
+//
+//  SCValdiTeardownRepro.mm
+//  helloworld
+//
+
+#import "SCValdiTeardownRepro.h"
+
+// Generated bridge-function class SCCTeardownProbeMakeTeardownProbe for makeTeardownProbe (see
+// teardown_probe/src/TeardownReproProbe.ts). The +functionWithJSRuntime: classes live in the
+// module umbrella header (SCCTeardownProbe), not the *Types header.
+#import <SCCTeardownProbe/SCCTeardownProbe.h>
+
+#import <valdi/ios/SCValdiRuntime.h>
+#import <valdi/ios/SCValdiRuntimeManager.h>
+#import <valdi_core/SCValdiError.h>
+#import <valdi_core/SCValdiJSRuntime.h>
+
+#include <cstring>
+
+#include "valdi/runtime/Interfaces/ITweakValueProvider.hpp"
+#include "valdi/runtime/RuntimeManager.hpp"
+#include "valdi_core/cpp/Utils/Shared.hpp"
+#include "valdi_core/cpp/Utils/StringBox.hpp"
+#include "valdi_core/cpp/Utils/Value.hpp"
+
+namespace {
+
+// Reports a fixed value for VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE so the harness can drive both
+// kill-switch states; every other key falls through to its caller-supplied fallback. The value is
+// cached on the JS runtime (Runtime::setRuntimeTweaks -> setResolutionTeardownDegradeEnabled) before
+// teardown detaches the listener, so it stays reachable while the runtime is being disposed.
+class TeardownDegradeProvider : public Valdi::SharedPtrRefCountable, public Valdi::ITweakValueProvider {
+  public:
+    explicit TeardownDegradeProvider(bool degradeEnabled) : _degradeEnabled(degradeEnabled) {}
+
+    Valdi::StringBox getString(const Valdi::StringBox &, const Valdi::StringBox &fallback) override {
+        return fallback;
+    }
+    bool getBool(const Valdi::StringBox &key, bool fallback) override {
+        if (std::strcmp(key.getCStr(), "VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE") == 0) {
+            return _degradeEnabled;
+        }
+        return fallback;
+    }
+    float getFloat(const Valdi::StringBox &, float fallback) override { return fallback; }
+    int32_t getInt(const Valdi::StringBox &, int32_t fallback) override { return fallback; }
+    Valdi::Value getBinary(const Valdi::StringBox &, const Valdi::Value &fallback) override { return fallback; }
+
+  private:
+    bool _degradeEnabled;
+};
+
+} // namespace
+
+@implementation SCValdiTeardownRepro
+
++ (void)reproduceWithDegradeEnabled:(BOOL)degradeEnabled
+{
+    // Isolated runtime so teardown can be forced without touching the app's shared runtime.
+    // __block so the async worker below can drop the last strong reference and trigger teardown.
+    __block SCValdiRuntimeManager *manager = [SCValdiRuntimeManager new];
+
+    // Force the main runtime into existence and capture its JS runtime. jsRuntime is captured
+    // strongly; it outlives the manager and keeps the disposed runtime addressable after teardown.
+    SCValdiRuntime *runtime = manager.mainRuntime;
+    id<SCValdiJSRuntime> jsRuntime = [runtime jsRuntime];
+    runtime = nil;
+
+    // Pin the resolution-teardown degrade to the requested state on this isolated runtime.
+    // setTweakValueProvider propagates through Runtime::setRuntimeTweaks to the JS runtime's cached
+    // kill-switch value, so it is captured before teardown detaches the listener.
+    auto *cppManager = static_cast<Valdi::RuntimeManager *>(manager.cppInstance);
+    if (cppManager != nullptr) {
+        cppManager->setTweakValueProvider(
+            Valdi::makeShared<TeardownDegradeProvider>(degradeEnabled ? true : false).toShared());
+    }
+
+    // Everything runs off the main thread: async_strict_mode forbids bridge-function resolution on
+    // the main thread. Resolution happens on a plain global queue (not the runtime's JS thread,
+    // which is gone after teardown), matching how the crash is hit in production.
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        // Sanity: on the still-live runtime the probe resolves normally. Logged, never fatal — a
+        // failure here means the probe module isn't bundled, not a teardown misfire.
+        @try {
+            SCCTeardownProbeMakeTeardownProbe *live = [SCCTeardownProbeMakeTeardownProbe functionWithJSRuntime:jsRuntime];
+            NSLog(@"[TeardownRepro] live resolve ok: %@", live);
+        } @catch (SCValdiError *error) {
+            NSLog(@"[TeardownRepro] live resolve raised (probe module may not be bundled): %@", error.reason);
+        }
+
+        // Tear the runtime down. Dropping the manager's last strong reference runs its dealloc, which
+        // drives fullTeardown -> JavaScriptRuntime::teardown and disposes the runtime synchronously.
+        manager = nil;
+
+        if (degradeEnabled) {
+            // Degrade ON (shipped default): the raising functionWithJSRuntime: path returns a no-op
+            // function instead of raising, so a dying session unwinds quietly. No @try on purpose —
+            // this must NOT crash.
+            SCCTeardownProbeMakeTeardownProbe *afterTeardown = [SCCTeardownProbeMakeTeardownProbe functionWithJSRuntime:jsRuntime];
+            NSLog(@"[TeardownRepro] degrade ON: resolved after teardown without crashing: %@", afterTeardown);
+        } else {
+            // Degrade OFF (kill switch disabled): resolution after teardown raises an uncatchable
+            // SCValdiError below this ObjC frame and the process aborts (SIGABRT) — the original
+            // teardown crash. No @try on purpose: the point is the crash.
+            NSLog(@"[TeardownRepro] degrade OFF: resolving after teardown, expect SIGABRT...");
+            SCCTeardownProbeMakeTeardownProbe *afterTeardown = [SCCTeardownProbeMakeTeardownProbe functionWithJSRuntime:jsRuntime];
+            NSLog(@"[TeardownRepro] UNEXPECTED: resolution did not crash: %@", afterTeardown);
+        }
+    });
+}
+
+@end

--- a/apps/helloworld/src/valdi/hello_world/src/HelloWorldApp.tsx
+++ b/apps/helloworld/src/valdi/hello_world/src/HelloWorldApp.tsx
@@ -6,7 +6,12 @@ import { Label, ScrollView } from 'valdi_tsx/src/NativeTemplateElements';
 import res from '../res';
 import { ByteExactImageExample } from './ByteExactImageExample';
 import { onRootComponentCreated } from './CppModule';
-import { APP_NAME, reproduceTeardownCrash, reproduceTeardownDegraded } from './NativeModule';
+import {
+  APP_NAME,
+  reproduceTeardownCrash,
+  reproduceTeardownDegraded,
+  reproduceTeardownInvocationCrash,
+} from './NativeModule';
 
 /**
  * @ViewModel
@@ -75,6 +80,24 @@ export class App extends Component<ViewModel, ComponentContext> {
         >
           <label
             value="⚠️ Resolve after teardown (degrade OFF — SIGABRT)"
+            font={systemFont(16)}
+            style={styles.reproCrashLabel}
+          />
+        </view>
+        {/* Debug-only: resolve (degrades to a no-op) then INVOKE after teardown — the invocation
+            returns a null value in a nonnull slot; passing it to a nonnull-requiring API
+            (+[NSURL fileURLWithPath:]) aborts (SIGABRT). Shows the degrade relocating a resolution
+            abort into an invocation nil-in-nonnull crash. */}
+        <view
+          marginTop={12}
+          padding={12}
+          backgroundColor="#f7eeee"
+          borderRadius={8}
+          onTap={reproduceTeardownInvocationCrash}
+          accessibilityId="teardown-invocation-button"
+        >
+          <label
+            value="💥 Invoke after teardown (nil → nonnull → SIGABRT)"
             font={systemFont(16)}
             style={styles.reproCrashLabel}
           />

--- a/apps/helloworld/src/valdi/hello_world/src/HelloWorldApp.tsx
+++ b/apps/helloworld/src/valdi/hello_world/src/HelloWorldApp.tsx
@@ -6,7 +6,7 @@ import { Label, ScrollView } from 'valdi_tsx/src/NativeTemplateElements';
 import res from '../res';
 import { ByteExactImageExample } from './ByteExactImageExample';
 import { onRootComponentCreated } from './CppModule';
-import { APP_NAME } from './NativeModule';
+import { APP_NAME, reproduceTeardownCrash, reproduceTeardownDegraded } from './NativeModule';
 
 /**
  * @ViewModel
@@ -46,6 +46,39 @@ export class App extends Component<ViewModel, ComponentContext> {
           />
         </layout>
         <ByteExactImageExample />
+        {/* Debug-only: resolve a bridge function after teardown with the resolution-teardown
+            degrade ON (shipped default) — returns a no-op, no crash. iOS-only; no-op on
+            android/web. */}
+        <view
+          marginTop={24}
+          padding={12}
+          backgroundColor="#eef7ee"
+          borderRadius={8}
+          onTap={reproduceTeardownDegraded}
+          accessibilityId="teardown-degrade-button"
+        >
+          <label
+            value="✅ Resolve after teardown (degrade ON — no crash)"
+            font={systemFont(16)}
+            style={styles.reproSafeLabel}
+          />
+        </view>
+        {/* Debug-only: same resolution with the degrade kill switch OFF — raises an uncatchable
+            SCValdiError and aborts (SIGABRT), reproducing the original teardown crash. */}
+        <view
+          marginTop={12}
+          padding={12}
+          backgroundColor="#f7eeee"
+          borderRadius={8}
+          onTap={reproduceTeardownCrash}
+          accessibilityId="teardown-crash-button"
+        >
+          <label
+            value="⚠️ Resolve after teardown (degrade OFF — SIGABRT)"
+            font={systemFont(16)}
+            style={styles.reproCrashLabel}
+          />
+        </view>
       </scroll>
     </view>;
   }
@@ -61,5 +94,13 @@ const styles = {
     color: 'black',
     accessibilityCategory: 'header',
     width: '100%',
+  }),
+
+  reproSafeLabel: new Style<Label>({
+    color: '#1b5e20',
+  }),
+
+  reproCrashLabel: new Style<Label>({
+    color: '#b00020',
   }),
 };

--- a/apps/helloworld/src/valdi/hello_world/src/NativeModule.d.ts
+++ b/apps/helloworld/src/valdi/hello_world/src/NativeModule.d.ts
@@ -6,3 +6,14 @@
 // Used to show case how a native module can be implemented and
 // used within TypeScript.
 export const APP_NAME: string;
+
+// Debug-only: demonstrates the bridge-function resolution teardown behavior. iOS runs the native
+// harness (SCValdiTeardownRepro); android and web are intentional no-ops (this is iOS-specific).
+
+// Degrade ON (shipped default): resolves a bridge function after teardown; returns a no-op and does
+// NOT crash.
+export function reproduceTeardownDegraded(): void;
+
+// Degrade OFF (kill switch disabled): resolves a bridge function after teardown; aborts the process
+// (SIGABRT) — the original teardown crash.
+export function reproduceTeardownCrash(): void;

--- a/apps/helloworld/src/valdi/hello_world/src/NativeModule.d.ts
+++ b/apps/helloworld/src/valdi/hello_world/src/NativeModule.d.ts
@@ -17,3 +17,8 @@ export function reproduceTeardownDegraded(): void;
 // Degrade OFF (kill switch disabled): resolves a bridge function after teardown; aborts the process
 // (SIGABRT) — the original teardown crash.
 export function reproduceTeardownCrash(): void;
+
+// Invocation after teardown: resolution degrades to a no-op, invoking it returns a null value in a
+// nonnull-typed slot; passing that null to a non-null-requiring API (+[NSURL fileURLWithPath:])
+// aborts the process (SIGABRT).
+export function reproduceTeardownInvocationCrash(): void;

--- a/apps/helloworld/src/valdi/hello_world/web/NativeModule.ts
+++ b/apps/helloworld/src/valdi/hello_world/web/NativeModule.ts
@@ -12,3 +12,7 @@ export function reproduceTeardownDegraded(): void {
 export function reproduceTeardownCrash(): void {
   console.log('[TeardownRepro] no-op on web');
 }
+
+export function reproduceTeardownInvocationCrash(): void {
+  console.log('[TeardownRepro] no-op on web');
+}

--- a/apps/helloworld/src/valdi/hello_world/web/NativeModule.ts
+++ b/apps/helloworld/src/valdi/hello_world/web/NativeModule.ts
@@ -3,3 +3,12 @@
 // "Web".
 
 export const APP_NAME: string = 'Valdi Hello World (Web)';
+
+// No-op on web: the teardown crash is iOS-specific.
+export function reproduceTeardownDegraded(): void {
+  console.log('[TeardownRepro] no-op on web');
+}
+
+export function reproduceTeardownCrash(): void {
+  console.log('[TeardownRepro] no-op on web');
+}

--- a/apps/helloworld/src/valdi/teardown_probe/BUILD.bazel
+++ b/apps/helloworld/src/valdi/teardown_probe/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//bzl/valdi:valdi_module.bzl", "valdi_module")
+
+# Minimal module hosting the teardown-repro probe. Kept separate from the hello_world module so the
+# native harness (which resolves the probe's generated bridge-function class) can depend on this
+# module's umbrella without a dependency cycle — a module's own native code cannot depend on that
+# same module's generated bindings.
+valdi_module(
+    name = "teardown_probe",
+    srcs = glob([
+        "src/**/*.ts",
+    ]) + [
+        "tsconfig.json",
+    ],
+    android_class_path = "com.snap.valdi.modules.teardown_probe",
+    android_output_target = "debug",
+    # async_strict_mode makes @ExportFunction resolution go through the raising
+    # +functionWithJSRuntime: path (SCValdiBridgeFunction) that aborts on runtime teardown.
+    async_strict_mode = True,
+    ios_module_name = "SCCTeardownProbe",
+    ios_output_target = "debug",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/valdi_modules/src/valdi/valdi_core",
+    ],
+)

--- a/apps/helloworld/src/valdi/teardown_probe/src/TeardownReproProbe.ts
+++ b/apps/helloworld/src/valdi/teardown_probe/src/TeardownReproProbe.ts
@@ -1,13 +1,15 @@
-// Probe for the bridge-function resolution teardown behavior.
+// Probe for the bridge-function teardown behavior (resolution and invocation).
 //
-// The native repro (SCValdiTeardownRepro on iOS) resolves this factory through the RAISING path —
-// +[SCCTeardownProbeMakeTeardownProbe functionWithJSRuntime:] — after the JS runtime has been torn
-// down. Only the resolution is exercised; the returned object is never used.
+// The native repro (SCValdiTeardownRepro on iOS) exercises this module two ways after the JS runtime
+// has been torn down:
+//   - RESOLUTION: +[SCCTeardownProbeMakeTeardownProbe functionWithJSRuntime:] (the raising path).
+//   - INVOCATION: invoking getTeardownPath after teardown, where the degrade returns a null value in
+//     a nonnull-typed slot.
 //
-// The factory returns an exported proxy (not an export-model and not void) so codegen emits a
-// SCValdiBridgeFunction subclass with +functionWithJSRuntime: — the resolution path that raises on
-// teardown — rather than a plain callable block. Mirrors makeTestObject in valdi_test's
-// FunctionTest.ts. The module is built with async_strict_mode so that class is generated.
+// makeTeardownProbe returns an exported proxy (not an export-model and not void) so codegen emits a
+// SCValdiBridgeFunction subclass with +functionWithJSRuntime: (the resolution path). getTeardownPath
+// returns a string so its degraded invocation yields a null in a `_Nonnull` NSString. The module is
+// built with async_strict_mode so those classes are generated.
 
 /**
  * @ExportProxy
@@ -25,4 +27,14 @@ class JsTeardownProbe implements TeardownProbeApi {
  */
 export function makeTeardownProbe(): TeardownProbeApi {
   return new JsTeardownProbe();
+}
+
+/**
+ * @ExportFunction
+ */
+// String return: invoking this after teardown yields a null string in a `_Nonnull` slot. Passed to a
+// nonnull-requiring API (e.g. +[NSURL fileURLWithPath:]), the null crashes — the invocation-teardown
+// nil-in-nonnull crash.
+export function getTeardownPath(): string {
+  return 'teardown_probe/ok';
 }

--- a/apps/helloworld/src/valdi/teardown_probe/src/TeardownReproProbe.ts
+++ b/apps/helloworld/src/valdi/teardown_probe/src/TeardownReproProbe.ts
@@ -1,0 +1,28 @@
+// Probe for the bridge-function resolution teardown behavior.
+//
+// The native repro (SCValdiTeardownRepro on iOS) resolves this factory through the RAISING path —
+// +[SCCTeardownProbeMakeTeardownProbe functionWithJSRuntime:] — after the JS runtime has been torn
+// down. Only the resolution is exercised; the returned object is never used.
+//
+// The factory returns an exported proxy (not an export-model and not void) so codegen emits a
+// SCValdiBridgeFunction subclass with +functionWithJSRuntime: — the resolution path that raises on
+// teardown — rather than a plain callable block. Mirrors makeTestObject in valdi_test's
+// FunctionTest.ts. The module is built with async_strict_mode so that class is generated.
+
+/**
+ * @ExportProxy
+ */
+export interface TeardownProbeApi {
+  ping(): void;
+}
+
+class JsTeardownProbe implements TeardownProbeApi {
+  ping(): void {}
+}
+
+/**
+ * @ExportFunction
+ */
+export function makeTeardownProbe(): TeardownProbeApi {
+  return new JsTeardownProbe();
+}

--- a/apps/helloworld/src/valdi/teardown_probe/tsconfig.json
+++ b/apps/helloworld/src/valdi/teardown_probe/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../_configs/base.tsconfig.json"
+}


### PR DESCRIPTION
Add a debug-only teardown repro to the Hello World iOS app: an isolated runtime is torn down mid-resolution, then a probe bridge function is resolved through the raising +functionWithJSRuntime: path. Two buttons show both sides of the resolution-teardown degrade (VALDI_ENABLE_RESOLUTION_TEARDOWN_DEGRADE): degrade on returns a no-op (no crash), degrade off aborts (SIGABRT).

Android/web wire the buttons to no-ops (iOS-specific).

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation improvement
- [ ] Performance optimization
- [ ] Test improvement
- [ ] Other (please describe)

## Testing
- [ ] Tests pass locally (`bazel test //...`)
- [ ] Added/updated tests for changes (if applicable)
- [ ] Tested on multiple platforms (iOS/Android/Web/macOS as applicable)
- [ ] Manual testing performed (describe below)

### Testing Details
<!-- Describe the testing you performed -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or documented in description)
- [ ] Commit messages follow [conventional format](../CONTRIBUTING.md#commit-messages)
- [ ] No secrets, API keys, or internal URLs included

## Related Issues
<!-- Link related issues using: Closes #(issue), Fixes #(issue), Relates to #(issue) -->

## Additional Context
<!-- Add any other context, screenshots, or information that would help reviewers -->
