### PR TITLE
Fix two persistent CI-blocking test-harness bugs (macOS SIGSEGV + Linux death-test timeout)

### DIFF
--- a/valdi/test/integration/Runtime_tests.cpp
+++ b/valdi/test/integration/Runtime_tests.cpp
@@ -7097,6 +7097,13 @@ TEST_P(RuntimeFixture, DISABLED_moduleResourceTrackerFreedUnderJsThreadIsUseAfte
 // async_strict_mode and the function is not annotated with @AllowSyncCall. Uses a dedicated
 // test_async_strict module (async_strict_mode=True) so the main test module can stay non-strict.
 TEST_P(RuntimeFixture, AsyncStrictModeSyncCallAssertsOnMainThread) {
+    // This fixture owns a live runtime with several worker/JS threads. The default "fast"
+    // death-test style fork()s in place, so the child inherits those threads frozen mid-flight;
+    // on loaded CI runners the child then stalls for ~90s on an orphaned lock before the assert's
+    // abort() completes, and the parameterized variants blow the suite timeout. "threadsafe"
+    // re-execs a fresh process for the death check, so no locked mutexes are inherited.
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
     wrapper.flushQueues();
 
     // test_async_strict has async_strict_mode=True; compute() has no @AllowSyncCall.

--- a/valdi/test/macos/SCValdiMacOSViewManagerTests.mm
+++ b/valdi/test/macos/SCValdiMacOSViewManagerTests.mm
@@ -366,14 +366,22 @@ static Ref<ViewNode> makeTestViewNode(AttributeIds& attributeIds) {
 
 - (void)testPhysicalTextEditingAppliesWillChangeAndSynchronizesNativeOverrides {
     // Driving a live field editor requires a key window + first responder, which needs an Aqua GUI
-    // session. Headless CI runners (no WindowServer) crash in window activation instead of running,
-    // so skip there; the assertions below still execute on machines with a GUI session.
+    // session. A non-NULL session dictionary is necessary but not sufficient: CI runners (e.g.
+    // GitHub Actions macOS) report a login session yet cannot host a live key window, and window
+    // activation SIGSEGVs there. Require the session to be active on the console, and bail out
+    // under CI where no usable WindowServer is guaranteed. The assertions below still execute on
+    // developer machines with a real GUI session.
     CFDictionaryRef guiSession = CGSessionCopyCurrentDictionary();
-    BOOL hasGuiSession = guiSession != NULL;
+    BOOL onConsole = NO;
     if (guiSession != NULL) {
+        CFBooleanRef onConsoleValue =
+            (CFBooleanRef)CFDictionaryGetValue(guiSession, kCGSessionOnConsoleKey);
+        onConsole = (onConsoleValue != NULL) && CFBooleanGetValue(onConsoleValue);
         CFRelease(guiSession);
     }
-    XCTSkipUnless(hasGuiSession, @"Requires an Aqua GUI session; skipping on headless CI.");
+    BOOL runningUnderCI = NSProcessInfo.processInfo.environment[@"CI"] != nil;
+    XCTSkipUnless(onConsole && !runningUnderCI,
+                  @"Requires an interactive Aqua GUI session; skipping on headless/CI runners.");
 
     NSWindow *window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 320, 200)
                                                    styleMask:NSWindowStyleMaskBorderless


### PR DESCRIPTION
## Problem

Two jobs have been persistently red on `main` — **macOS: C++ & Platform Tests** and **Linux: C++ Tests** (same shape across the last several nightly runs). Neither is a product regression; both are test-harness bugs that only manifest on CI runners.

## Root causes & fixes

### Linux — `//valdi:test` TIMEOUT
`RuntimeTests/RuntimeFixture.AsyncStrictModeSyncCallAssertsOnMainThread` is the only `EXPECT_DEATH` in the suite. It uses the default **"fast"** death-test style, which `fork()`s in place. The fixture owns a live runtime with several worker/JS threads, so the forked child inherits them frozen mid-flight (gtest even warns: *"Death tests use fork() … detected 12 threads"*). On loaded CI runners the child then stalls **~94 s** on an orphaned lock before the assert's `abort()` completes; three parameterized variants blow the `//valdi:test` timeout.

Fix: switch this test to **"threadsafe"** death-test style, which re-execs a fresh process for the death check so no locked mutexes are inherited.

### macOS — SIGSEGV in `valdi_macos_objc_test`
`testPhysicalTextEditingAppliesWillChangeAndSynchronizesNativeOverrides` intends to skip on headless CI, but gated the skip on `CGSessionCopyCurrentDictionary() != NULL`. GitHub's macOS runners report a login session, so the guard failed to skip; the test then drove a live key window + first responder + field editor and **SIGSEGV'd in AppKit window activation** (before any assertion — exactly the failure the test's own comment predicts).

Fix: require the session to be **active on the console** (`kCGSessionOnConsoleKey`) and bail out under CI, where no usable WindowServer is guaranteed. The live-editor path still runs on developer machines with a real GUI session. (The test was already a no-op on CI by design; this just makes the skip actually fire there.)

## Verification

- Linux: reproduced locally and confirmed the fix — the 4 variants now finish in **~30–50 ms each** (previously 94 s+ per variant on CI) with `--gtest_print_time=1`. The `"fast"`→`"threadsafe"` re-exec works fine under the Bazel test sandbox.
- macOS: header-only/logic change (`CoreGraphics` already imported); the Apple-only target builds under the macOS CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
